### PR TITLE
동시성 해결 - 낙관적 락, 비관적 락 적용

### DIFF
--- a/src/main/java/kr/hhplus/be/server/api/token/application/TokenApplication.java
+++ b/src/main/java/kr/hhplus/be/server/api/token/application/TokenApplication.java
@@ -37,7 +37,7 @@ public class TokenApplication implements TokenUsecase{
     @Transactional
     public WaitingQueue createToken(Long userId)
     {
-        User user = userReader.readByIdWithLock(userId);
+        User user = userReader.readByIdWithOptimisticLock(userId);
         String uuid = user.getUuid();
         if (Objects.isNull(uuid)) {
             uuid = UUID.randomUUID().toString();

--- a/src/main/java/kr/hhplus/be/server/api/user/application/UserApplication.java
+++ b/src/main/java/kr/hhplus/be/server/api/user/application/UserApplication.java
@@ -21,9 +21,11 @@ public class UserApplication implements UserUsecase {
     public User chargePoint(Long point)
     {
         User user = UserContext.getContext();
-        userReader.readByIdWithLock(user.getId());
+        userReader.readByIdWithPessimisticLock(user.getId());
         user.chargePoint(point);
-        return userModifier.modifyUser(user);
+        // 비관적 락의 경우, update 쿼리시에 version 검증이 나가는 것을 방지
+        userModifier.modifyUserWithoutVersion(user);
+        return user;
     }
 
     @Transactional

--- a/src/main/java/kr/hhplus/be/server/domain/reservation/Reservation.java
+++ b/src/main/java/kr/hhplus/be/server/domain/reservation/Reservation.java
@@ -49,6 +49,9 @@ public class Reservation {
 
     private LocalDateTime expiredAt;
 
+    @Version
+    private int version;
+
     public void setConcert(Concert concert)
     {
         this.concert = concert;

--- a/src/main/java/kr/hhplus/be/server/domain/seat/Seat.java
+++ b/src/main/java/kr/hhplus/be/server/domain/seat/Seat.java
@@ -29,4 +29,7 @@ public class Seat {
     @Setter
     @Enumerated(EnumType.STRING)
     private SeatStatus status;
+
+    @Version
+    private int version;
 }

--- a/src/main/java/kr/hhplus/be/server/domain/user/User.java
+++ b/src/main/java/kr/hhplus/be/server/domain/user/User.java
@@ -33,6 +33,9 @@ public class User {
     @Builder.Default
     private List<WaitingQueue> waitingQueueList = new ArrayList<>();
 
+    @Version
+    private int version;
+
     public void chargePoint(Long chargePoint)
     {
         if (MAX_POINT < this.balance + chargePoint)

--- a/src/main/java/kr/hhplus/be/server/domain/user/components/UserModifier.java
+++ b/src/main/java/kr/hhplus/be/server/domain/user/components/UserModifier.java
@@ -16,4 +16,8 @@ public class UserModifier {
     {
         return userModifierRepository.modifyUser(user);
     }
+    public int modifyUserWithoutVersion(User user)
+    {
+        return userModifierRepository.modifyUserWithoutVersion(user);
+    }
 }

--- a/src/main/java/kr/hhplus/be/server/domain/user/components/UserReader.java
+++ b/src/main/java/kr/hhplus/be/server/domain/user/components/UserReader.java
@@ -18,9 +18,15 @@ public class UserReader {
                 .orElseThrow(() -> new ConcertException(ErrorCode.USER_NOT_FOUND));
     }
 
-    public User readByIdWithLock(Long userId)
+    public User readByIdWithOptimisticLock(Long userId)
     {
-        return userReaderRepository.readByIdWithLock(userId)
+        return userReaderRepository.readByIdWithOptimisticLock(userId)
+                .orElseThrow(() -> new ConcertException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    public User readByIdWithPessimisticLock(Long userId)
+    {
+        return userReaderRepository.readByIdWithPessimisticLock(userId)
                 .orElseThrow(() -> new ConcertException(ErrorCode.USER_NOT_FOUND));
     }
 

--- a/src/main/java/kr/hhplus/be/server/domain/user/repositories/UserModifierRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/user/repositories/UserModifierRepository.java
@@ -4,4 +4,5 @@ import kr.hhplus.be.server.domain.user.User;
 
 public interface UserModifierRepository {
     public User modifyUser(User user);
+    public int modifyUserWithoutVersion(User user);
 }

--- a/src/main/java/kr/hhplus/be/server/domain/user/repositories/UserReaderRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/user/repositories/UserReaderRepository.java
@@ -6,7 +6,8 @@ import java.util.Optional;
 
 public interface UserReaderRepository {
     public Optional<User> readById(Long userId);
-    public Optional<User> readByIdWithLock(Long userId);
+    public Optional<User> readByIdWithOptimisticLock(Long userId);
+    public Optional<User> readByIdWithPessimisticLock(Long userId);
     public Optional<User> readByUuid(String uuid);
     public Optional<User> readByUuidWithLock(String uuid);
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/core/concert/ConcertJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/core/concert/ConcertJpaRepository.java
@@ -1,13 +1,17 @@
 package kr.hhplus.be.server.infrastructure.core.concert;
 
 import kr.hhplus.be.server.domain.concert.Concert;
+import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.awt.print.Pageable;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 public interface ConcertJpaRepository extends JpaRepository<Concert, Long> {
     public Optional<Concert> findByDate(LocalDate date);
+
     public List<Concert> findAllByDateBetween(LocalDate startDate, LocalDate endDate);
 }
+//    public Page<Concert> findAllByDateBetween(LocalDate startDate, LocalDate endDate, Pageable pageable);

--- a/src/main/java/kr/hhplus/be/server/infrastructure/core/reservation/ReservationJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/core/reservation/ReservationJpaRepository.java
@@ -14,7 +14,8 @@ import java.util.Optional;
 
 @Repository
 public interface ReservationJpaRepository extends JpaRepository<Reservation, Long> {
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
+//    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Lock(LockModeType.OPTIMISTIC)
     @Query("select r from Reservation r where r.id=:reservationId")
     Optional<Reservation> findByIdWithLock(@Param("reservationId") Long reservationId);
 

--- a/src/main/java/kr/hhplus/be/server/infrastructure/core/seat/SeatJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/core/seat/SeatJpaRepository.java
@@ -13,7 +13,8 @@ import java.util.Optional;
 public interface SeatJpaRepository extends JpaRepository<Seat, Long> {
     List<Seat> findAllByConcertId(Long concertId);
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
+//    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Lock(LockModeType.OPTIMISTIC)
     @Query("select s from Seat s where s.concert.id=:concertId and s.number=:seatNumber")
     Optional<Seat> findByConcertIdAndNumberWithLock(@Param("concertId") Long concertId, @Param("seatNumber") Long seatNumber);
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/core/user/UserJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/core/user/UserJpaRepository.java
@@ -4,6 +4,7 @@ import jakarta.persistence.LockModeType;
 import kr.hhplus.be.server.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,11 +13,21 @@ import java.util.Optional;
 public interface UserJpaRepository extends JpaRepository<User, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select u from User u where u.id=:userId")
-    Optional<User> findByIdWithLock(@Param("userId") Long userId);
+    Optional<User> findByIdWithPessimisticLock(@Param("userId") Long userId);
+
+    @Lock(LockModeType.OPTIMISTIC)
+    @Query("select u from User u where u.id=:userId")
+    Optional<User> findByIdWithOptimisticLock(@Param("userId") Long userId);
 
     Optional<User> findByUuid(String uuid);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select u from User u where u.uuid=:uuid")
     Optional<User> findByUuidWithLock(@Param("uuid") String uuid);
+
+    @Modifying
+    @Query("update User u set u.balance=:balance, u.uuid=:uuid where u.id=:userId")
+    int saveWithoutVersion(
+            @Param("userId") Long userId, @Param("balance") Long balance, @Param("uuid") String uuid
+    );
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/core/user/UserModifierRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/core/user/UserModifierRepositoryImpl.java
@@ -14,4 +14,9 @@ public class UserModifierRepositoryImpl implements UserModifierRepository {
     public User modifyUser(User user) {
         return userJpaRepository.save(user);
     }
+
+    @Override
+    public int modifyUserWithoutVersion(User user) {
+        return userJpaRepository.saveWithoutVersion(user.getId(), user.getBalance(), user.getUuid());
+    }
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/core/user/UserReaderRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/core/user/UserReaderRepositoryImpl.java
@@ -13,8 +13,13 @@ public class UserReaderRepositoryImpl implements UserReaderRepository {
     private final UserJpaRepository userJpaRepository;
 
     @Override
-    public Optional<User> readByIdWithLock(Long userId) {
-        return userJpaRepository.findByIdWithLock(userId);
+    public Optional<User> readByIdWithOptimisticLock(Long userId) {
+        return userJpaRepository.findByIdWithOptimisticLock(userId);
+    }
+
+    @Override
+    public Optional<User> readByIdWithPessimisticLock(Long userId) {
+        return userJpaRepository.findByIdWithPessimisticLock(userId);
     }
 
     @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
   jpa:
     open-in-view: false
     generate-ddl: false
-    show-sql: true
+    show-sql: false
     hibernate:
       ddl-auto: none
     properties:
@@ -33,3 +33,11 @@ spring:
     url: jdbc:mysql://localhost:3306/hhplus?characterEncoding=UTF-8&serverTimezone=UTC
     username: root
     password: root
+
+---
+spring.config.activate.on-profile: test
+
+spring:
+  datasource:
+    hikari:
+      maximum-pool-size: 5

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -9,7 +9,8 @@ CREATE TABLE IF NOT EXISTS seat (
   `concert_id` int,
   `number` int,
   `cost` int,
-  `status` varchar(255)
+  `status` varchar(255),
+  `version` int not null default 0
 );
 
 CREATE TABLE IF NOT EXISTS waiting_queue (
@@ -28,7 +29,8 @@ CREATE TABLE IF NOT EXISTS reservation (
   `seat_number` int,
   `seat_cost` int,
   `status` varchar(255),
-  `expired_at` datetime
+  `expired_at` datetime,
+  `version` int not null default 0
 );
 
 CREATE TABLE IF NOT EXISTS payment (
@@ -42,5 +44,6 @@ CREATE TABLE IF NOT EXISTS payment (
 CREATE TABLE IF NOT EXISTS user (
   `user_id` int AUTO_INCREMENT PRIMARY KEY,
   `balance` int,
-  `uuid` varchar(255)
+  `uuid` varchar(255),
+  `version` int not null default 0
 );

--- a/src/test/java/kr/hhplus/be/server/api/payment/application/PaymentApplicationIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/payment/application/PaymentApplicationIntegrationTest.java
@@ -13,21 +13,27 @@ import kr.hhplus.be.server.infrastructure.core.user.UserJpaRepository;
 import kr.hhplus.be.server.infrastructure.core.waiting_queue.WaitingQueueJpaRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.shaded.org.apache.commons.lang3.time.StopWatch;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 
 @ActiveProfiles("test")
 @SpringBootTest
 class PaymentApplicationIntegrationTest {
+    Logger logger = LoggerFactory.getLogger(this.getClass());
+
     @Autowired
     UserJpaRepository userJpaRepository;
     @Autowired
@@ -81,7 +87,7 @@ class PaymentApplicationIntegrationTest {
     }
 
     @Test
-    void 동시에_3번_결제하면_2번_오류()
+    void 동시에_30번_결제하면_29번_오류()
     {
         // given
         User user = userJpaRepository.save(
@@ -112,17 +118,29 @@ class PaymentApplicationIntegrationTest {
 
         // when
         List<CompletableFuture<Boolean>> futures = new ArrayList<>();
-        for(int i = 0; i < 3; i++) {
+        for(int i = 0; i < 30; i++) {
             futures.add(CompletableFuture.supplyAsync(
                     () -> {
+                        StopWatch timer = new StopWatch();
+                        timer.start();
+
                         try {
                             UserContext.setContext(user);
 
                             paymentApplication.pay(
                                     reservation.getId()
                             );
+
+                            timer.stop();
+                            logger.info(
+                                    "정상 메소드 실행 시간: {}ms", timer.getTime(TimeUnit.MILLISECONDS)
+                            );
                             return true;
                         } catch (RuntimeException re) {
+                            timer.stop();
+                            logger.info(
+                                    "비정상 메소드 실행 시간: {}ms", timer.getTime(TimeUnit.MILLISECONDS)
+                            );
                             return false;
                         }
                     }
@@ -130,6 +148,9 @@ class PaymentApplicationIntegrationTest {
         }
 
         CompletableFuture[] futuresArray = futures.toArray(new CompletableFuture[futures.size()]);
+
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
 
         CompletableFuture.allOf(futuresArray)
                 .thenRun(() ->
@@ -144,7 +165,10 @@ class PaymentApplicationIntegrationTest {
                             })
                             .count();
 
-                    Assertions.assertThat(success_count).isEqualTo(2L);
+                    Assertions.assertThat(success_count).isEqualTo(29L);
                 }).join();
+
+        stopWatch.stop();
+        logger.info("총 소요시간: {}ms", stopWatch.getTime(TimeUnit.MILLISECONDS));
     }
 }

--- a/src/test/java/kr/hhplus/be/server/api/token/application/TokenApplicationUnitTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/token/application/TokenApplicationUnitTest.java
@@ -44,7 +44,7 @@ class TokenApplicationUnitTest {
         //given
         Mockito.doReturn(
                 User.builder().build()
-        ).when(userReader).readByIdWithLock(Mockito.anyLong());
+        ).when(userReader).readByIdWithOptimisticLock(Mockito.anyLong());
         Mockito.doReturn(
                 List.of(
                         WaitingQueue.builder().build(),
@@ -196,7 +196,7 @@ class TokenApplicationUnitTest {
     {
         // given
         Mockito.doReturn(User.builder().build())
-                .when(userReader).readByIdWithLock(Mockito.anyLong());
+                .when(userReader).readByIdWithOptimisticLock(Mockito.anyLong());
         Mockito.doReturn(true)
                 .when(waitingQueueReader)
                 .isValidTokenExists(Mockito.any());

--- a/src/test/java/kr/hhplus/be/server/api/user/application/UserApplicationIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/user/application/UserApplicationIntegrationTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.Executors;
 @ActiveProfiles("test")
 @SpringBootTest
 class UserApplicationIntegrationTest {
+
     @Autowired
     private UserJpaRepository userJpaRepository;
 

--- a/src/test/java/kr/hhplus/be/server/api/user/application/UserApplicationUnitTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/user/application/UserApplicationUnitTest.java
@@ -40,7 +40,7 @@ class UserApplicationUnitTest {
         // when
         userApplication.chargePoint(10000L);
 
-        Mockito.verify(userModifier).modifyUser(userCaptor.capture());
+        Mockito.verify(userModifier).modifyUserWithoutVersion(userCaptor.capture());
         User capturedUser = userCaptor.getValue();
 
         //then

--- a/src/test/java/kr/hhplus/be/server/infrastructure/core/user/UserReaderRepositoryImplTest.java
+++ b/src/test/java/kr/hhplus/be/server/infrastructure/core/user/UserReaderRepositoryImplTest.java
@@ -39,7 +39,7 @@ class UserReaderRepositoryImplTest {
 
         // when, then
         Assertions.assertThat(
-                userReaderRepository.readByIdWithLock(user.getId())
+                userReaderRepository.readByIdWithOptimisticLock(user.getId())
         ).isNotEmpty();
     }
 


### PR DESCRIPTION
### **커밋 링크**
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.

필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->
- WIKI - 동시성 이슈 및 락기법 관련 보고서 <-- STEP 11
- [develop] 낙관적 락 적용 및 메서드 소요시간 측정 테스트 d6c8eb5d223158f8596b44568d663ff9ab75666c <-- STEP 12
---
### **리뷰 포인트(질문)**
- 리뷰 포인트 1
한 유저가 여러 토큰 생성 요청(createToken)에도 하나의 활성화 토큰만 가질 수 없다는 동시성 문제를 해결하기 위해 낙관적 락을 사용하였고, 한 유저가 동시에 여러 번 충전 요청(chargePoint)에도 순차적으로 충전을 수행한다는 동시성 문제를 해결하기 위해 비관적 락을 사용하였습니다. 이를 구현하기 위해서는 userRepository가 비관적 락 메소드와 낙관적 락 메소드를 모두 가지고 있어야 했습니다. 하지만 비관적 락 메소드를 호출했는데도 update 쿼리시에 version 컬럼을 비교하는 문제가 발생하였습니다. 이를 해결하기 위해 버전 검증을 수행하지 않는 update 쿼리를 따로 만들어서 비관적 락을 사용할 시에는 그 쿼리를 호출하도록 구현하였는데, 실무에서는 어떻게 하시는지 궁금합니다.
- 리뷰 포인트 2
낙관적 락과 비관적 락의 성능 테스트를 위해 총 소요시간, 정상적인 메소드의 소요시간, 비정상적인(예외가 발생한) 메소드의 소요시간을 측정하려고 하였습니다. 측정 결과, 비관적 락의 경우는 대기시간 때문에 나중에 도착한 스레드의 소요시간이 점차 증가하는 현상을 확인할 수 있었지만, 낙관적 락의 경우도 스레드의 소요시간이 점차 증가하는 이상한 현상(대기하지 않기 때문에 모든 스레드의 소요시간이 거의 비슷할 것이라고 생각하였습니다.)을 확인하였습니다. 저의 측정 방법이 잘못된 건지 제가 고려하지 못한 변수(cpu, os등)가 있을 수 있는건지, 아니면 알맞은 결과인지 잘 모르겠습니다 ㅠㅠ
( WIKI에 측정 결과 화면이 있습니다. )
<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->
낙관적 락과 비관적 락의 고정관념을 깨는 계기가 되었다. ( 낙관적 락은 충돌이 잦지 않을 경우에만 사용하는 것이라고 착각하고 있었다. )

### Problem
<!--개선이 필요한 점-->
보고서 위주의 과제라 상대적으로 쉬울 것이라고 판단해 일요일에 놀았던 것이 문제였다. ( 내 실력에 왜 논 건지 후회가 된다.)

### Try
<!-- 새롭게 시도할 점 -->
시간이 없어 레디스를 활용한 락 기법에 대해 분석해보지 못한것 같아 레디스 및 카프카까지 더 공부해보자