### PR TITLE
Redis를 활용한 DB 부하 개선

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,10 @@ dependencies {
 	compileOnly("org.projectlombok:lombok")
 	annotationProcessor("org.projectlombok:lombok")
 
+	// redis
+	implementation("org.springframework.boot:spring-boot-starter-data-redis")
+	implementation("org.redisson:redisson-spring-boot-starter:3.18.0")
+
 	// Swagger
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,9 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 	implementation("org.redisson:redisson-spring-boot-starter:3.18.0")
 
+	// json
+	implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3")
+
 	// Swagger
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,13 @@ services:
     volumes:
       - ./data/mysql/:/var/lib/mysql
 
+  redis:
+    image: redis:7.0
+    ports:
+      - "6379:6379"
+    volumes:
+      - ./data/redis/:/data
+
 networks:
   default:
     driver: bridge

--- a/src/main/java/kr/hhplus/be/server/api/concert/application/ConcertApplication.java
+++ b/src/main/java/kr/hhplus/be/server/api/concert/application/ConcertApplication.java
@@ -2,15 +2,10 @@ package kr.hhplus.be.server.api.concert.application;
 
 import kr.hhplus.be.server.api.concert.dto.AvailableConcertDto;
 import kr.hhplus.be.server.api.concert.dto.AvailableConcertDtoList;
-import kr.hhplus.be.server.common.exception.ConcertException;
-import kr.hhplus.be.server.common.exception.ErrorCode;
-import kr.hhplus.be.server.domain.concert.Concert;
+import kr.hhplus.be.server.common.aop.DistributedLock;
 import kr.hhplus.be.server.domain.concert.components.ConcertReader;
 import kr.hhplus.be.server.domain.token.components.WaitingQueueReader;
-import kr.hhplus.be.server.domain.token.type.WaitingQueueStatus;
-import kr.hhplus.be.server.domain.user.User;
 import kr.hhplus.be.server.domain.user.components.UserReader;
-import kr.hhplus.be.server.api.concert.dto.GetAvailableConcertsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -18,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +21,7 @@ public class ConcertApplication implements ConcertUsecase{
     private final WaitingQueueReader waitingQueueReader;
     private final ConcertReader concertReader;
 
+    @DistributedLock(key ="T(String).format('%s-%s', #startDate, #endDate)")
     @Cacheable(value="available-concerts", key="T(String).format('%s-%s', #startDate, #endDate)")
     @Transactional
     @Override
@@ -43,5 +38,6 @@ public class ConcertApplication implements ConcertUsecase{
     @CacheEvict(value = "available-concerts", allEntries = true)
     public void clearAvailableConcerts()
     {
+
     }
 }

--- a/src/main/java/kr/hhplus/be/server/api/concert/application/ConcertUsecase.java
+++ b/src/main/java/kr/hhplus/be/server/api/concert/application/ConcertUsecase.java
@@ -1,5 +1,7 @@
 package kr.hhplus.be.server.api.concert.application;
 
+import kr.hhplus.be.server.api.concert.dto.AvailableConcertDto;
+import kr.hhplus.be.server.api.concert.dto.AvailableConcertDtoList;
 import kr.hhplus.be.server.api.concert.dto.GetAvailableConcertsResponse;
 import kr.hhplus.be.server.domain.concert.Concert;
 
@@ -7,5 +9,5 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface ConcertUsecase {
-    public List<Concert> getAvailableConcerts(LocalDate startDate, LocalDate endDate);
+    public AvailableConcertDtoList getAvailableConcerts(LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/kr/hhplus/be/server/api/concert/dto/AvailableConcertDto.java
+++ b/src/main/java/kr/hhplus/be/server/api/concert/dto/AvailableConcertDto.java
@@ -1,0 +1,32 @@
+package kr.hhplus.be.server.api.concert.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import kr.hhplus.be.server.domain.concert.Concert;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class AvailableConcertDto
+{
+    private Long concertId;
+    private String name;
+
+    @JsonSerialize(using = LocalDateSerializer.class)
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    @JsonFormat(shape= JsonFormat.Shape.STRING, pattern="yyyy-MM-dd")
+    private LocalDate date;
+
+    public static AvailableConcertDto from(Concert concert)
+    {
+        return new AvailableConcertDto(concert.getId(), concert.getName(), concert.getDate());
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/concert/dto/AvailableConcertDtoList.java
+++ b/src/main/java/kr/hhplus/be/server/api/concert/dto/AvailableConcertDtoList.java
@@ -1,0 +1,23 @@
+package kr.hhplus.be.server.api.concert.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class AvailableConcertDtoList
+{
+    private List<AvailableConcertDto> availableConcertDtoList;
+
+    public static AvailableConcertDtoList from(
+            List<AvailableConcertDto> availableConcertDtoList
+    )
+    {
+        return new AvailableConcertDtoList(availableConcertDtoList);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/concert/dto/GetAvailableConcertsResponse.java
+++ b/src/main/java/kr/hhplus/be/server/api/concert/dto/GetAvailableConcertsResponse.java
@@ -4,8 +4,8 @@ import kr.hhplus.be.server.domain.concert.Concert;
 
 import java.util.List;
 
-public record GetAvailableConcertsResponse(List<Concert> availableConcerts) {
-    public static GetAvailableConcertsResponse from(List<Concert> concertList)
+public record GetAvailableConcertsResponse(AvailableConcertDtoList availableConcerts) {
+    public static GetAvailableConcertsResponse from(AvailableConcertDtoList concertList)
     {
         return new GetAvailableConcertsResponse(concertList);
     }

--- a/src/main/java/kr/hhplus/be/server/api/reservation/application/ReservationApplication.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/application/ReservationApplication.java
@@ -66,7 +66,7 @@ public class ReservationApplication implements ReservationUsecase{
         // lock을 걸어 가져와야 하기 때문에 concert.getSeatList() (x)
         Seat seat = seatReader.readAvailableSeatByConcertIdAndNumberWithLock(concert.getId(), seatNumber);
 
-        seat.setStatus(SeatStatus.RESERVED);
+        seatModifier.setReserved(seat);
 
         LocalDateTime expiredTime = LocalDateTime.now().plusMinutes(RESERVATION_LIFETIME_IN_MINUTES);
         Reservation reservation = Reservation.builder()
@@ -78,7 +78,6 @@ public class ReservationApplication implements ReservationUsecase{
         reservation.setSeat(seat);
 
         reservationWriter.writeReservation(reservation);
-        seatModifier.modifySeat(seat);
 
         // 레디스 명령어를 제일 마지막에 수행함으로써 레디스 트랜잭션 사용 X
         // 토큰 값 덮어쓰기

--- a/src/main/java/kr/hhplus/be/server/api/seat/application/SeatUsecase.java
+++ b/src/main/java/kr/hhplus/be/server/api/seat/application/SeatUsecase.java
@@ -6,5 +6,5 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface SeatUsecase {
-    public List<Seat> getAvailableSeatsByDate(LocalDate date);
+    public List<Long> getAvailableSeatsByDate(LocalDate date);
 }

--- a/src/main/java/kr/hhplus/be/server/api/seat/dto/GetAvailableSeatsResponse.java
+++ b/src/main/java/kr/hhplus/be/server/api/seat/dto/GetAvailableSeatsResponse.java
@@ -4,11 +4,11 @@ import kr.hhplus.be.server.domain.seat.Seat;
 
 import java.util.List;
 
-public record GetAvailableSeatsResponse(List<SeatResponse> availableSeats) {
-    public static GetAvailableSeatsResponse from(List<Seat> availableSeats)
+public record GetAvailableSeatsResponse(List<SeatResponse> availableSeatNumber) {
+    public static GetAvailableSeatsResponse from(List<Long> availableSeatNumber)
     {
         return new GetAvailableSeatsResponse(
-                availableSeats.stream().map(SeatResponse::of).toList()
+                availableSeatNumber.stream().map(SeatResponse::of).toList()
         );
     }
 }

--- a/src/main/java/kr/hhplus/be/server/api/seat/dto/SeatResponse.java
+++ b/src/main/java/kr/hhplus/be/server/api/seat/dto/SeatResponse.java
@@ -3,16 +3,9 @@ package kr.hhplus.be.server.api.seat.dto;
 import kr.hhplus.be.server.domain.seat.Seat;
 import kr.hhplus.be.server.domain.seat.type.SeatStatus;
 
-public record SeatResponse(
-        Long seatId, Long seatNumber, Long seatCost, SeatStatus status
-) {
-    public static SeatResponse of(Seat seat)
+public record SeatResponse(Long seatNumber) {
+    public static SeatResponse of(Long seatNumber)
     {
-        return new SeatResponse(
-                seat.getId(),
-                seat.getConcert().getId(),
-                seat.getNumber(),
-                seat.getStatus()
-        );
+        return new SeatResponse(seatNumber);
     }
 }

--- a/src/main/java/kr/hhplus/be/server/api/token/application/TokenUsecase.java
+++ b/src/main/java/kr/hhplus/be/server/api/token/application/TokenUsecase.java
@@ -5,6 +5,6 @@ import kr.hhplus.be.server.api.token.dto.GetTokenResponse;
 import kr.hhplus.be.server.domain.token.WaitingQueue;
 
 public interface TokenUsecase {
-    public WaitingQueue createToken(Long userId);
+    public String createToken(Long userId);
     public Long getToken();
 }

--- a/src/main/java/kr/hhplus/be/server/api/token/dto/CreateTokenResponse.java
+++ b/src/main/java/kr/hhplus/be/server/api/token/dto/CreateTokenResponse.java
@@ -4,8 +4,8 @@ import kr.hhplus.be.server.domain.token.WaitingQueue;
 import kr.hhplus.be.server.domain.token.type.WaitingQueueStatus;
 
 public record CreateTokenResponse(String uuid, WaitingQueueStatus status) {
-    public static CreateTokenResponse from(WaitingQueue token)
+    public static CreateTokenResponse from(String uuid)
     {
-        return new CreateTokenResponse(token.getUser().getUuid(), token.getStatus());
+        return new CreateTokenResponse(uuid, WaitingQueueStatus.WAIT);
     }
 }

--- a/src/main/java/kr/hhplus/be/server/common/aop/CustomSpringELParser.java
+++ b/src/main/java/kr/hhplus/be/server/common/aop/CustomSpringELParser.java
@@ -1,0 +1,21 @@
+package kr.hhplus.be.server.common.aop;
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public class CustomSpringELParser {
+    private CustomSpringELParser() {
+    }
+
+    public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/common/aop/DistributedLock.java
+++ b/src/main/java/kr/hhplus/be/server/common/aop/DistributedLock.java
@@ -1,0 +1,33 @@
+package kr.hhplus.be.server.common.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+    /**
+     * 락의 이름
+     */
+    String key();
+
+    /**
+     * 락의 시간 단위
+     */
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    /**
+     * 락을 기다리는 시간 (default - 5s)
+     * 락 획득을 위해 waitTime 만큼 대기한다
+     */
+    long waitTime() default 5L;
+
+    /**
+     * 락 임대 시간 (default - 3s)
+     * 락을 획득한 이후 leaseTime 이 지나면 락을 해제한다
+     */
+    long leaseTime() default 3L;
+}

--- a/src/main/java/kr/hhplus/be/server/common/aop/DistributedLockAop.java
+++ b/src/main/java/kr/hhplus/be/server/common/aop/DistributedLockAop.java
@@ -1,0 +1,46 @@
+package kr.hhplus.be.server.common.aop;
+
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class DistributedLockAop {
+    private static final String REDISSON_LOCK_PREFIX = "LOCK:";
+    private final RedissonClient redissonClient;
+
+    @Around("@annotation(kr.hhplus.be.server.common.aop.DistributedLock)")
+    public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+
+        String key = REDISSON_LOCK_PREFIX + CustomSpringELParser.getDynamicValue(signature.getParameterNames(), joinPoint.getArgs(), distributedLock.key());
+        RLock rLock = redissonClient.getLock(key);  // (1)
+
+        try {
+            boolean available = rLock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), distributedLock.timeUnit());  // (2)
+            if (!available) {
+                return false;
+            }
+
+            return joinPoint.proceed();  // (3)
+        } catch (InterruptedException e) {
+            throw new InterruptedException();
+        } finally {
+            rLock.unlock();
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/common/config/redis/RedisConfig.java
+++ b/src/main/java/kr/hhplus/be/server/common/config/redis/RedisConfig.java
@@ -1,0 +1,33 @@
+package kr.hhplus.be.server.common.config.redis;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(
+            @Autowired RedisConnectionFactory redisConnectionFactory
+    )
+    {
+        StringRedisTemplate stringRedisTemplate = new StringRedisTemplate();
+        stringRedisTemplate.setConnectionFactory(redisConnectionFactory);
+        return stringRedisTemplate;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/common/config/redis/RedisConfig.java
+++ b/src/main/java/kr/hhplus/be/server/common/config/redis/RedisConfig.java
@@ -1,14 +1,29 @@
 package kr.hhplus.be.server.common.config.redis;
 
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+import static org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair.fromSerializer;
 
 @Configuration
+@EnableCaching
 public class RedisConfig {
     @Value("${spring.data.redis.host}")
     private String host;
@@ -29,5 +44,21 @@ public class RedisConfig {
         StringRedisTemplate stringRedisTemplate = new StringRedisTemplate();
         stringRedisTemplate.setConnectionFactory(redisConnectionFactory);
         return stringRedisTemplate;
+    }
+
+    @Bean
+    public RedisCacheManager redisCacheManager(RedisConnectionFactory connectionFactory)
+    {
+        RedisCacheConfiguration configuration
+                = RedisCacheConfiguration
+                .defaultCacheConfig()
+                .serializeKeysWith(fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofSeconds(30));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(connectionFactory)
+                .cacheDefaults(configuration)
+                .build();
     }
 }

--- a/src/main/java/kr/hhplus/be/server/common/config/redis/RedisConfig.java
+++ b/src/main/java/kr/hhplus/be/server/common/config/redis/RedisConfig.java
@@ -61,4 +61,16 @@ public class RedisConfig {
                 .cacheDefaults(configuration)
                 .build();
     }
+
+    @Bean
+    public RedissonClient redissonClient()
+    {
+        RedissonClient redissonClient = null;
+        Config config = new Config();
+        config.useSingleServer().setAddress(
+                String.format("redis://%s:%s", host, String.valueOf(port))
+        );
+        redissonClient = Redisson.create(config);
+        return redissonClient;
+    }
 }

--- a/src/main/java/kr/hhplus/be/server/domain/seat/components/SeatModifier.java
+++ b/src/main/java/kr/hhplus/be/server/domain/seat/components/SeatModifier.java
@@ -5,6 +5,8 @@ import kr.hhplus.be.server.domain.seat.repositories.SeatModifierRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+
 @RequiredArgsConstructor
 @Service
 public class SeatModifier {
@@ -13,5 +15,15 @@ public class SeatModifier {
     public Seat modifySeat(Seat seat)
     {
         return seatModifierRepository.modifySeat(seat);
+    }
+
+    public void setAvailable(Seat seat)
+    {
+        seatModifierRepository.setAvailable(seat);
+    }
+
+    public void setReserved(Seat seat)
+    {
+        seatModifierRepository.setReserved(seat);
     }
 }

--- a/src/main/java/kr/hhplus/be/server/domain/seat/components/SeatReader.java
+++ b/src/main/java/kr/hhplus/be/server/domain/seat/components/SeatReader.java
@@ -9,6 +9,7 @@ import kr.hhplus.be.server.domain.seat.type.SeatStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -24,6 +25,11 @@ public class SeatReader {
             throw new ConcertException(ErrorCode.AVAILABLE_SEAT_NOT_FOUND);
 
         return seatList;
+    }
+
+    public List<Long> getUnavailableSeatsByDate(LocalDate date)
+    {
+        return seatReaderRepository.getUnavailableSeatsByDate(date);
     }
 
     public Seat readAvailableSeatByConcertIdAndNumberWithLock(Long concertId, Long seatNumber)

--- a/src/main/java/kr/hhplus/be/server/domain/seat/repositories/SeatModifierRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/seat/repositories/SeatModifierRepository.java
@@ -2,6 +2,10 @@ package kr.hhplus.be.server.domain.seat.repositories;
 
 import kr.hhplus.be.server.domain.seat.Seat;
 
+import java.time.LocalDate;
+
 public interface SeatModifierRepository {
     public Seat modifySeat(Seat seat);
+    public void setAvailable(Seat seat);
+    public void setReserved(Seat seat);
 }

--- a/src/main/java/kr/hhplus/be/server/domain/seat/repositories/SeatReaderRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/seat/repositories/SeatReaderRepository.java
@@ -2,6 +2,7 @@ package kr.hhplus.be.server.domain.seat.repositories;
 
 import kr.hhplus.be.server.domain.seat.Seat;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -9,4 +10,5 @@ public interface SeatReaderRepository {
     public List<Seat> getSeatsByConcertId(Long concertId);
     public Optional<Seat> getSeatByConcertIdAndNumberWithLock(Long concertId, Long seatNumber);
     public Optional<Seat> getById(Long seatId);
+    public List<Long> getUnavailableSeatsByDate(LocalDate date);
 }

--- a/src/main/java/kr/hhplus/be/server/domain/token/components/WaitingQueueModifier.java
+++ b/src/main/java/kr/hhplus/be/server/domain/token/components/WaitingQueueModifier.java
@@ -21,4 +21,19 @@ public class WaitingQueueModifier {
     {
         waitingQueueModifierRepository.deleteAllTokens(tokenList);
     }
+
+    public List<String> deleteWaitTokens(long count)
+    {
+        return waitingQueueModifierRepository.deleteWaitTokens(count);
+    }
+
+    public void deleteAllExpiredTokens(double nanoSeconds)
+    {
+        waitingQueueModifierRepository.deleteAllExpiredTokens(nanoSeconds);
+    }
+
+    public void changeExpiredTime(String uuid, double expiredAt)
+    {
+        waitingQueueModifierRepository.changeExpiredTime(uuid, expiredAt);
+    }
 }

--- a/src/main/java/kr/hhplus/be/server/domain/token/components/WaitingQueueReader.java
+++ b/src/main/java/kr/hhplus/be/server/domain/token/components/WaitingQueueReader.java
@@ -60,9 +60,27 @@ public class WaitingQueueReader {
         return waitingQueueReaderRepository.readActiveTokenLimitBy(PageRequest.of(0, 1)).orElseThrow(() -> new ConcertException(ErrorCode.ACTIVE_TOKEN_NOT_FOUND));
     }
 
-    public boolean isValidTokenExists(User user)
+    public boolean isWaitingTokenExists(String uuid)
     {
-        return user.getWaitingQueueList().stream()
-                .anyMatch(t -> t.getStatus() != WaitingQueueStatus.EXPIRED);
+        return waitingQueueReaderRepository.getWaitingToken(uuid).isPresent();
+    }
+
+    public boolean isActiveTokenExists(String uuid)
+    {
+        return waitingQueueReaderRepository.getActiveToken(uuid).isPresent();
+    }
+
+    public long getWaitingNumber(String uuid)
+    {
+        if(waitingQueueReaderRepository.getActiveToken(uuid).isPresent())
+            return 0L;
+
+        return waitingQueueReaderRepository.getWaitingNumber(uuid)
+                .orElseThrow(() -> new ConcertException(ErrorCode.TOKEN_NOT_FOUND));
+    }
+
+    public long getActiveTokensCount()
+    {
+        return waitingQueueReaderRepository.getActiveTokensCount();
     }
 }

--- a/src/main/java/kr/hhplus/be/server/domain/token/components/WaitingQueueWriter.java
+++ b/src/main/java/kr/hhplus/be/server/domain/token/components/WaitingQueueWriter.java
@@ -14,4 +14,14 @@ public class WaitingQueueWriter {
     {
         return waitingQueueWriterRepository.writeToken(waitingQueue);
     }
+
+    public boolean writeWaitingToken(String uuid, double createdAt)
+    {
+        return waitingQueueWriterRepository.writeWaitingToken(uuid, createdAt);
+    }
+
+    public boolean writeActiveToken(String uuid, double expiredAt)
+    {
+        return waitingQueueWriterRepository.writeActiveToken(uuid, expiredAt);
+    }
 }

--- a/src/main/java/kr/hhplus/be/server/domain/token/repositories/WaitingQueueModifierRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/token/repositories/WaitingQueueModifierRepository.java
@@ -1,10 +1,15 @@
 package kr.hhplus.be.server.domain.token.repositories;
 
 import kr.hhplus.be.server.domain.token.WaitingQueue;
+import org.springframework.data.redis.core.ZSetOperations;
 
 import java.util.List;
+import java.util.Set;
 
 public interface WaitingQueueModifierRepository {
     public WaitingQueue modifyToken(WaitingQueue waitingQueue);
     public void deleteAllTokens(List<WaitingQueue> token);
+    public List<String> deleteWaitTokens(long count);
+    public void deleteAllExpiredTokens(double nanoSeconds);
+    public void changeExpiredTime(String uuid, double expiredAt);
 }

--- a/src/main/java/kr/hhplus/be/server/domain/token/repositories/WaitingQueueReaderRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/token/repositories/WaitingQueueReaderRepository.java
@@ -2,9 +2,11 @@ package kr.hhplus.be.server.domain.token.repositories;
 
 import kr.hhplus.be.server.domain.token.WaitingQueue;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.ZSetOperations;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface WaitingQueueReaderRepository {
     public List<WaitingQueue> readTokensByUuidWithLock(String uuid);
@@ -13,4 +15,9 @@ public interface WaitingQueueReaderRepository {
     public List<WaitingQueue> readAllActiveTokensWithLock();
     public List<WaitingQueue> readWaitTokensLimitBy(Pageable pageable);
     public Optional<WaitingQueue> readActiveTokenLimitBy(Pageable pageable);
+
+    public Optional<Double> getWaitingToken(String uuid);
+    public Optional<Double> getActiveToken(String uuid);
+    public Optional<Long> getWaitingNumber(String uuid);
+    public long getActiveTokensCount();
 }

--- a/src/main/java/kr/hhplus/be/server/domain/token/repositories/WaitingQueueWriterRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/token/repositories/WaitingQueueWriterRepository.java
@@ -4,4 +4,7 @@ import kr.hhplus.be.server.domain.token.WaitingQueue;
 
 public interface WaitingQueueWriterRepository {
     public WaitingQueue writeToken(WaitingQueue waitingQueue);
+
+    public boolean writeWaitingToken(String uuid, double createdAt);
+    public boolean writeActiveToken(String uuid, double expiredAt);
 }

--- a/src/main/java/kr/hhplus/be/server/domain/user/User.java
+++ b/src/main/java/kr/hhplus/be/server/domain/user/User.java
@@ -4,10 +4,7 @@ import jakarta.persistence.*;
 import kr.hhplus.be.server.common.exception.ConcertException;
 import kr.hhplus.be.server.common.exception.ErrorCode;
 import kr.hhplus.be.server.domain.token.WaitingQueue;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,6 +24,7 @@ public class User {
     private Long id;
 
     private Long balance;
+    @Setter
     private String uuid;
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)

--- a/src/main/java/kr/hhplus/be/server/infrastructure/core/seat/SeatModifierRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/core/seat/SeatModifierRepositoryImpl.java
@@ -2,16 +2,45 @@ package kr.hhplus.be.server.infrastructure.core.seat;
 
 import kr.hhplus.be.server.domain.seat.Seat;
 import kr.hhplus.be.server.domain.seat.repositories.SeatModifierRepository;
+import kr.hhplus.be.server.domain.seat.type.SeatStatus;
+import kr.hhplus.be.server.infrastructure.redis.SeatRedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static kr.hhplus.be.server.infrastructure.redis.SeatRedisRepository.UNAVAILABLE_SEAT_SET_PREFIX;
 
 @Repository
 @RequiredArgsConstructor
 public class SeatModifierRepositoryImpl implements SeatModifierRepository{
     private final SeatJpaRepository seatJpaRepository;
+    private final SeatRedisRepository seatRedisRepository;
 
     @Override
     public Seat modifySeat(Seat seat) {
         return seatJpaRepository.save(seat);
+    }
+
+    @Override
+    public void setReserved(Seat seat) {
+        seat.setStatus(SeatStatus.RESERVED);
+        seatJpaRepository.save(seat);
+        seatRedisRepository.SetAdd(
+                UNAVAILABLE_SEAT_SET_PREFIX + seat.getConcert().getDate(),
+                seat.getNumber().toString()
+        );
+    }
+
+    @Override
+    public void setAvailable(Seat seat) {
+        seat.setStatus(SeatStatus.AVAILABLE);
+        seatJpaRepository.save(seat);
+        seatRedisRepository.SetRemove(
+                UNAVAILABLE_SEAT_SET_PREFIX + seat.getConcert().getDate(),
+                seat.getNumber().toString()
+        );
     }
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/core/seat/SeatReaderRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/core/seat/SeatReaderRepositoryImpl.java
@@ -2,16 +2,29 @@ package kr.hhplus.be.server.infrastructure.core.seat;
 
 import kr.hhplus.be.server.domain.seat.Seat;
 import kr.hhplus.be.server.domain.seat.repositories.SeatReaderRepository;
+import kr.hhplus.be.server.infrastructure.redis.SeatRedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+
+import static kr.hhplus.be.server.infrastructure.redis.SeatRedisRepository.UNAVAILABLE_SEAT_SET_PREFIX;
 
 @Repository
 @RequiredArgsConstructor
 public class SeatReaderRepositoryImpl implements SeatReaderRepository {
     private final SeatJpaRepository seatJpaRepository;
+    private final SeatRedisRepository seatRedisRepository;
+
+    @Override
+    public List<Long> getUnavailableSeatsByDate(LocalDate date) {
+        return seatRedisRepository.SetMembers(UNAVAILABLE_SEAT_SET_PREFIX + date.toString())
+                .stream()
+                .map(Long::valueOf)
+                .toList();
+    }
 
     @Override
     public List<Seat> getSeatsByConcertId(Long concertId) {

--- a/src/main/java/kr/hhplus/be/server/infrastructure/core/waiting_queue/WaitingQueueModifierRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/core/waiting_queue/WaitingQueueModifierRepositoryImpl.java
@@ -2,15 +2,28 @@ package kr.hhplus.be.server.infrastructure.core.waiting_queue;
 
 import kr.hhplus.be.server.domain.token.WaitingQueue;
 import kr.hhplus.be.server.domain.token.repositories.WaitingQueueModifierRepository;
+import kr.hhplus.be.server.infrastructure.redis.TokenRedisRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+
+import static kr.hhplus.be.server.infrastructure.redis.TokenRedisRepository.ACTIVE_TOKEN_SET_NAME;
+import static kr.hhplus.be.server.infrastructure.redis.TokenRedisRepository.WAIT_TOKEN_SET_NAME;
 
 @Repository
 @RequiredArgsConstructor
 public class WaitingQueueModifierRepositoryImpl implements WaitingQueueModifierRepository {
     private final WaitingQueueJpaRepository waitingQueueJpaRepository;
+    private final TokenRedisRepository tokenRedisRepository;
+
+    @Override
+    public List<String> deleteWaitTokens(long count) {
+        return tokenRedisRepository.zSetPopMin(WAIT_TOKEN_SET_NAME, count).stream()
+                .map(ZSetOperations.TypedTuple::getValue)
+                .toList();
+    }
 
     @Override
     public WaitingQueue modifyToken(WaitingQueue token) {
@@ -20,5 +33,15 @@ public class WaitingQueueModifierRepositoryImpl implements WaitingQueueModifierR
     @Override
     public void deleteAllTokens(List<WaitingQueue> tokenList) {
         waitingQueueJpaRepository.deleteAll(tokenList);
+    }
+
+    @Override
+    public void deleteAllExpiredTokens(double nanoSeconds) {
+        tokenRedisRepository.zSetRemoveRangeByScore(ACTIVE_TOKEN_SET_NAME, 0, nanoSeconds);
+    }
+
+    @Override
+    public void changeExpiredTime(String uuid, double expiredAt) {
+        tokenRedisRepository.zSetModify(ACTIVE_TOKEN_SET_NAME, uuid, expiredAt);
     }
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/core/waiting_queue/WaitingQueueReaderRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/core/waiting_queue/WaitingQueueReaderRepositoryImpl.java
@@ -3,6 +3,7 @@ package kr.hhplus.be.server.infrastructure.core.waiting_queue;
 import kr.hhplus.be.server.domain.token.WaitingQueue;
 import kr.hhplus.be.server.domain.token.repositories.WaitingQueueReaderRepository;
 import kr.hhplus.be.server.domain.token.type.WaitingQueueStatus;
+import kr.hhplus.be.server.infrastructure.redis.TokenRedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
@@ -10,10 +11,14 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
 
+import static kr.hhplus.be.server.infrastructure.redis.TokenRedisRepository.ACTIVE_TOKEN_SET_NAME;
+import static kr.hhplus.be.server.infrastructure.redis.TokenRedisRepository.WAIT_TOKEN_SET_NAME;
+
 @Repository
 @RequiredArgsConstructor
 public class WaitingQueueReaderRepositoryImpl implements WaitingQueueReaderRepository {
     private final WaitingQueueJpaRepository waitingQueueJpaRepository;
+    private final TokenRedisRepository tokenRedisRepository;
 
     @Override
     public List<WaitingQueue> readTokensByUuidWithLock(String uuid) {
@@ -43,5 +48,31 @@ public class WaitingQueueReaderRepositoryImpl implements WaitingQueueReaderRepos
     @Override
     public Optional<WaitingQueue> readActiveTokenLimitBy(Pageable pageable) {
         return waitingQueueJpaRepository.findAllByStatusDESCWithPage(WaitingQueueStatus.ACTIVE, pageable).stream().findFirst();
+    }
+
+    @Override
+    public Optional<Double> getWaitingToken(String uuid) {
+        return Optional.ofNullable(
+                tokenRedisRepository.zSetScore(WAIT_TOKEN_SET_NAME, uuid)
+        );
+    }
+
+    @Override
+    public Optional<Double> getActiveToken(String uuid) {
+        return Optional.ofNullable(
+                tokenRedisRepository.zSetScore(ACTIVE_TOKEN_SET_NAME, uuid)
+        );
+    }
+
+    @Override
+    public Optional<Long> getWaitingNumber(String uuid) {
+        return Optional.ofNullable(
+                tokenRedisRepository.zSetRank(WAIT_TOKEN_SET_NAME, uuid)
+        );
+    }
+
+    @Override
+    public long getActiveTokensCount() {
+        return tokenRedisRepository.zSetCard(ACTIVE_TOKEN_SET_NAME);
     }
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/core/waiting_queue/WaitingQueueWriterRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/core/waiting_queue/WaitingQueueWriterRepositoryImpl.java
@@ -2,16 +2,31 @@ package kr.hhplus.be.server.infrastructure.core.waiting_queue;
 
 import kr.hhplus.be.server.domain.token.WaitingQueue;
 import kr.hhplus.be.server.domain.token.repositories.WaitingQueueWriterRepository;
+import kr.hhplus.be.server.infrastructure.redis.TokenRedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import static kr.hhplus.be.server.infrastructure.redis.TokenRedisRepository.ACTIVE_TOKEN_SET_NAME;
+import static kr.hhplus.be.server.infrastructure.redis.TokenRedisRepository.WAIT_TOKEN_SET_NAME;
 
 @Repository
 @RequiredArgsConstructor
 public class WaitingQueueWriterRepositoryImpl implements WaitingQueueWriterRepository {
     private final WaitingQueueJpaRepository waitingQueueJpaRepository;
+    private final TokenRedisRepository tokenRedisRepository;
 
     @Override
     public WaitingQueue writeToken(WaitingQueue token) {
         return waitingQueueJpaRepository.save(token);
+    }
+
+    @Override
+    public boolean writeWaitingToken(String uuid, double createdAt) {
+        return tokenRedisRepository.zSetAdd(WAIT_TOKEN_SET_NAME, uuid, createdAt);
+    }
+
+    @Override
+    public boolean writeActiveToken(String uuid, double expiredAt) {
+        return tokenRedisRepository.zSetAdd(ACTIVE_TOKEN_SET_NAME, uuid, expiredAt);
     }
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/redis/SeatRedisRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/redis/SeatRedisRepository.java
@@ -1,0 +1,31 @@
+package kr.hhplus.be.server.infrastructure.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Set;
+
+@Repository
+@RequiredArgsConstructor
+public class SeatRedisRepository {
+    public static final String UNAVAILABLE_SEAT_SET_PREFIX = "seats-unavailable";
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public Long SetAdd(String key, String value)
+    {
+        return stringRedisTemplate.opsForSet().add(key, value);
+    }
+
+    public Set<String> SetMembers(String key)
+    {
+        return stringRedisTemplate.opsForSet().members(key);
+    }
+
+    public Long SetRemove(String key, String value)
+    {
+        return stringRedisTemplate.opsForSet().remove(key, value);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/redis/TokenRedisRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/redis/TokenRedisRepository.java
@@ -1,0 +1,52 @@
+package kr.hhplus.be.server.infrastructure.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Repository;
+
+import java.util.Set;
+
+@Repository
+@RequiredArgsConstructor
+public class TokenRedisRepository {
+    public static final String WAIT_TOKEN_SET_NAME = "wait-tokens";
+    public static final String ACTIVE_TOKEN_SET_NAME = "active-tokens";
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public Boolean zSetAdd(String key, String member, double score)
+    {
+        return stringRedisTemplate.opsForZSet().addIfAbsent(key, member, score);
+    }
+
+    public Set<ZSetOperations.TypedTuple<String>> zSetPopMin(String key, long count)
+    {
+        return stringRedisTemplate.opsForZSet().popMin(key, count);
+    }
+
+    public Long zSetRank(String key, String member)
+    {
+        return stringRedisTemplate.opsForZSet().rank(key, member);
+    }
+
+    public Long zSetCard(String key)
+    {
+        return stringRedisTemplate.opsForZSet().zCard(key);
+    }
+
+    public Double zSetScore(String key, String member)
+    {
+        return stringRedisTemplate.opsForZSet().score(key, member);
+    }
+
+    public Long zSetRemoveRangeByScore(String key, double min, double max)
+    {
+        return stringRedisTemplate.opsForZSet().removeRangeByScore(key, min, max);
+    }
+
+    public Boolean zSetModify(String key, String member, double expiredAt)
+    {
+        return stringRedisTemplate.opsForZSet().add(key, member, expiredAt);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,7 +26,7 @@ spring:
       mode: always
 
 ---
-spring.config.activate.on-profile: local, test
+spring.config.activate.on-profile: local
 
 spring:
   datasource:
@@ -34,9 +34,13 @@ spring:
     username: root
     password: root
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
 ---
 spring.config.activate.on-profile: test
-
 spring:
   datasource:
     hikari:

--- a/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
+++ b/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
@@ -2,6 +2,9 @@ package kr.hhplus.be.server;
 
 import jakarta.annotation.PreDestroy;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -9,6 +12,7 @@ import org.testcontainers.utility.DockerImageName;
 class TestcontainersConfiguration {
 
 	public static final MySQLContainer<?> MYSQL_CONTAINER;
+	public static final GenericContainer<?> REDIS_CONTAINER;
 
 	static {
 		MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
@@ -20,12 +24,23 @@ class TestcontainersConfiguration {
 		System.setProperty("spring.datasource.url", MYSQL_CONTAINER.getJdbcUrl() + "?characterEncoding=UTF-8&serverTimezone=UTC");
 		System.setProperty("spring.datasource.username", MYSQL_CONTAINER.getUsername());
 		System.setProperty("spring.datasource.password", MYSQL_CONTAINER.getPassword());
+
+		REDIS_CONTAINER = new GenericContainer<>(DockerImageName.parse("redis:7.0"))
+				.withExposedPorts(6379);
+		REDIS_CONTAINER.start();
+
+		System.setProperty("spring.data.redis.host", REDIS_CONTAINER.getHost());
+		System.setProperty("spring.data.redis.port", REDIS_CONTAINER.getMappedPort(6379).toString());
 	}
 
 	@PreDestroy
 	public void preDestroy() {
 		if (MYSQL_CONTAINER.isRunning()) {
 			MYSQL_CONTAINER.stop();
+		}
+		if (REDIS_CONTAINER.isRunning())
+		{
+			REDIS_CONTAINER.stop();
 		}
 	}
 }

--- a/src/test/java/kr/hhplus/be/server/api/concert/application/ConcertApplicationIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/concert/application/ConcertApplicationIntegrationTest.java
@@ -14,6 +14,9 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import java.time.LocalDate;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 
 @ActiveProfiles("test")
@@ -63,5 +66,35 @@ class ConcertApplicationIntegrationTest {
 
         // then
         Assertions.assertThat(concertList.getAvailableConcertDtoList().size()).isEqualTo(3);
+    }
+
+    @Test
+    void 동시에_콘서트_조회시_캐시스탬피드현상_방지_성공() throws InterruptedException {
+        int threadCount = 3;
+        ExecutorService excecutorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // when
+        for (int i = 0; i < threadCount; i++)
+        {
+            excecutorService.submit(() -> {
+                try{
+                    concertApplication.getAvailableConcerts(
+                            LocalDate.of(2025,7, 1),
+                            LocalDate.of(2025,8 ,1)
+                    );
+                }
+                finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        excecutorService.shutdown();
+
+        // then
+        Mockito.verify(concertReader, Mockito.times(1))
+                .readByDateBetween(Mockito.any(), Mockito.any());
     }
 }

--- a/src/test/java/kr/hhplus/be/server/api/payment/application/PaymentApplicationUnitTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/payment/application/PaymentApplicationUnitTest.java
@@ -57,12 +57,6 @@ class PaymentApplicationUnitTest {
         );
 
         Mockito.doReturn(
-                WaitingQueue.builder()
-                        .status(WaitingQueueStatus.ACTIVE)
-                        .build()
-        ).when(waitingQueueReader).readValidToken(Mockito.any());
-
-        Mockito.doReturn(
                 Reservation.builder()
                         .seatCost(6000L)
                         .expiredAt(LocalDateTime.now().plusMinutes(1))
@@ -71,23 +65,23 @@ class PaymentApplicationUnitTest {
                         .build()
         ).when(reservationReader).readByIdWithLock(Mockito.anyLong());
 
-        ArgumentCaptor<WaitingQueue> tokenCaptor = ArgumentCaptor.forClass(WaitingQueue.class);
+        ArgumentCaptor<String> tokenCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Reservation> reservationCaptor = ArgumentCaptor.forClass(Reservation.class);
         ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
 
         // when
         paymentApplication.pay(1L);
 
-        Mockito.verify(waitingQueueModifier).modifyToken(tokenCaptor.capture());
+        Mockito.verify(waitingQueueModifier).changeExpiredTime(tokenCaptor.capture(), Mockito.anyDouble());
         Mockito.verify(userModifier).modifyUser(userCaptor.capture());
         Mockito.verify(reservationModifier).modifyReservation(reservationCaptor.capture());
 
-        WaitingQueue capturedToken = tokenCaptor.getValue();
+        String capturedToken = tokenCaptor.getValue();
         User capturedUser = userCaptor.getValue();
         Reservation capturedReservation = reservationCaptor.getValue();
 
         // then
-        Assertions.assertThat(capturedToken.getStatus()).isEqualTo(WaitingQueueStatus.EXPIRED);
+        Assertions.assertThat(capturedToken).isNotNull();
         Assertions.assertThat(capturedUser.getBalance()).isEqualTo(4000L);
         Assertions.assertThat(capturedReservation.getStatus()).isEqualTo(ReservationStatus.RESERVED);
     }
@@ -104,11 +98,6 @@ class PaymentApplicationUnitTest {
                         .build()
         );
 
-        Mockito.doReturn(
-                WaitingQueue.builder()
-                        .status(WaitingQueueStatus.ACTIVE)
-                        .build()
-        ).when(waitingQueueReader).readValidToken(Mockito.any());
         Mockito.doReturn(
                 Reservation.builder()
                         .expiredAt(LocalDateTime.now().minusMinutes(1))
@@ -137,11 +126,6 @@ class PaymentApplicationUnitTest {
         );
 
         Mockito.doReturn(
-                WaitingQueue.builder()
-                        .status(WaitingQueueStatus.ACTIVE)
-                        .build()
-        ).when(waitingQueueReader).readValidToken(Mockito.any());
-        Mockito.doReturn(
                 Reservation.builder()
                         .expiredAt(LocalDateTime.now().plusMinutes(5))
                         .status(ReservationStatus.RESERVED)
@@ -168,12 +152,6 @@ class PaymentApplicationUnitTest {
                         .balance(10000L)
                         .build()
         );
-
-        Mockito.doReturn(
-                WaitingQueue.builder()
-                        .status(WaitingQueueStatus.ACTIVE)
-                        .build()
-        ).when(waitingQueueReader).readValidToken(Mockito.any());
 
         Mockito.doReturn(
                 Reservation.builder()

--- a/src/test/java/kr/hhplus/be/server/api/reservation/application/ReservationApplicationIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/reservation/application/ReservationApplicationIntegrationTest.java
@@ -7,6 +7,7 @@ import kr.hhplus.be.server.domain.reservation.type.ReservationStatus;
 import kr.hhplus.be.server.domain.seat.type.SeatStatus;
 import kr.hhplus.be.server.domain.token.WaitingQueue;
 import kr.hhplus.be.server.domain.token.components.WaitingQueueReader;
+import kr.hhplus.be.server.domain.token.components.WaitingQueueWriter;
 import kr.hhplus.be.server.domain.token.type.WaitingQueueStatus;
 import kr.hhplus.be.server.domain.user.User;
 import kr.hhplus.be.server.infrastructure.core.user.UserJpaRepository;
@@ -41,6 +42,8 @@ class ReservationApplicationIntegrationTest {
 
     @Autowired
     private WaitingQueueReader waitingQueueReader;
+    @Autowired
+    private WaitingQueueWriter waitingQueueWriter;
 
     @Autowired
     private ReservationApplication reservationApplication;
@@ -59,12 +62,7 @@ class ReservationApplicationIntegrationTest {
         );
         userJpaRepository.flush();
 
-        WaitingQueue token = WaitingQueue.builder()
-                .status(WaitingQueueStatus.ACTIVE)
-                .build();
-        token.setUser(user);
-        waitingQueueJpaRepository.save(token);
-        waitingQueueJpaRepository.flush();
+        waitingQueueWriter.writeActiveToken(user.getUuid(),1234 );
 
         UserContext.setContext(user);
 
@@ -90,12 +88,7 @@ class ReservationApplicationIntegrationTest {
         );
         userJpaRepository.flush();
 
-        WaitingQueue token = WaitingQueue.builder()
-                .status(WaitingQueueStatus.ACTIVE)
-                .build();
-        token.setUser(user);
-        waitingQueueJpaRepository.save(token);
-        waitingQueueJpaRepository.flush();
+        waitingQueueWriter.writeActiveToken(user.getUuid(),1234 );
 
         // when
         List<CompletableFuture<Boolean>> futures = new ArrayList<>();

--- a/src/test/java/kr/hhplus/be/server/api/reservation/application/ReservationApplicationUnitTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/reservation/application/ReservationApplicationUnitTest.java
@@ -75,17 +75,15 @@ class ReservationApplicationUnitTest {
         // when
         reservationApplication.reserveSeat(LocalDate.now(), 10L);
         Mockito.verify(reservationWriter).writeReservation(reservationCaptor.capture());
-        Mockito.verify(seatModifier).modifySeat(seatCaptor.capture());
+        Mockito.verify(seatModifier, Mockito.times(1)).setReserved(Mockito.any());
         Mockito.verify(waitingQueueModifier).changeExpiredTime(tokenCaptor.capture(), Mockito.anyDouble());
 
         Reservation capturedReservation = reservationCaptor.getValue();
-        Seat capturedSeat = seatCaptor.getValue();
         String capturedToken = tokenCaptor.getValue();
         // then
         Assertions.assertThat(capturedReservation.getConcert()).isNotNull();
         Assertions.assertThat(capturedReservation.getUser()).isNotNull();
         Assertions.assertThat(capturedReservation.getSeat()).isNotNull();
-        Assertions.assertThat(capturedSeat.getStatus()).isEqualTo(SeatStatus.RESERVED);
         Assertions.assertThat(capturedToken).isNotNull();
     }
 

--- a/src/test/java/kr/hhplus/be/server/api/reservation/application/ReservationApplicationUnitTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/reservation/application/ReservationApplicationUnitTest.java
@@ -60,15 +60,8 @@ class ReservationApplicationUnitTest {
                 User.builder().uuid(UUID.randomUUID().toString()).build()
         );
 
-        Mockito.doReturn(
-                WaitingQueue.builder()
-                        .status(WaitingQueueStatus.ACTIVE)
-                        .build()
-        ).when(waitingQueueReader).readValidToken(Mockito.any());
-
         Mockito.doReturn(Concert.builder().id(1L).build())
                 .when(concertReader).getByDate(Mockito.any());
-
         Mockito.doReturn(
                 Seat.builder()
                         .status(SeatStatus.AVAILABLE)
@@ -77,24 +70,23 @@ class ReservationApplicationUnitTest {
 
         ArgumentCaptor<Reservation> reservationCaptor = ArgumentCaptor.forClass(Reservation.class);
         ArgumentCaptor<Seat> seatCaptor = ArgumentCaptor.forClass(Seat.class);
-        ArgumentCaptor<WaitingQueue> tokenCaptor = ArgumentCaptor.forClass(WaitingQueue.class);
+        ArgumentCaptor<String> tokenCaptor = ArgumentCaptor.forClass(String.class);
 
         // when
         reservationApplication.reserveSeat(LocalDate.now(), 10L);
         Mockito.verify(reservationWriter).writeReservation(reservationCaptor.capture());
         Mockito.verify(seatModifier).modifySeat(seatCaptor.capture());
-        Mockito.verify(waitingQueueModifier).modifyToken(tokenCaptor.capture());
+        Mockito.verify(waitingQueueModifier).changeExpiredTime(tokenCaptor.capture(), Mockito.anyDouble());
 
         Reservation capturedReservation = reservationCaptor.getValue();
         Seat capturedSeat = seatCaptor.getValue();
-        WaitingQueue capturedToken = tokenCaptor.getValue();
-
+        String capturedToken = tokenCaptor.getValue();
         // then
         Assertions.assertThat(capturedReservation.getConcert()).isNotNull();
         Assertions.assertThat(capturedReservation.getUser()).isNotNull();
         Assertions.assertThat(capturedReservation.getSeat()).isNotNull();
         Assertions.assertThat(capturedSeat.getStatus()).isEqualTo(SeatStatus.RESERVED);
-        Assertions.assertThat(capturedToken.getExpiredAt()).isNotNull();
+        Assertions.assertThat(capturedToken).isNotNull();
     }
 
     @Test

--- a/src/test/java/kr/hhplus/be/server/api/seat/application/SeatApplicationIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/seat/application/SeatApplicationIntegrationTest.java
@@ -35,29 +35,12 @@ class SeatApplicationIntegrationTest {
     @Transactional
     @Test
     void getAvailableSeatsByDate() {
-        // given
-        User user = userJpaRepository.save(
-                User.builder()
-                        .uuid(UUID.randomUUID().toString())
-                        .build()
-        );
-        userJpaRepository.flush();
-
-        WaitingQueue token = WaitingQueue.builder()
-                .status(WaitingQueueStatus.ACTIVE)
-                .build();
-        token.setUser(user);
-        waitingQueueJpaRepository.save(token);
-        waitingQueueJpaRepository.flush();
-
-        UserContext.setContext(user);
-
         // when
-        List<Seat> seatList = seatApplication.getAvailableSeatsByDate(
+        List<Long> seatNumberList = seatApplication.getAvailableSeatsByDate(
                 LocalDate.of(2025,7, 15)
         );
 
         // then
-        Assertions.assertThat(seatList.size()).isEqualTo(50);
+        Assertions.assertThat(seatNumberList.size()).isEqualTo(50);
     }
 }

--- a/src/test/java/kr/hhplus/be/server/infrastructure/core/seat/SeatModifierRepositoryImplTest.java
+++ b/src/test/java/kr/hhplus/be/server/infrastructure/core/seat/SeatModifierRepositoryImplTest.java
@@ -1,13 +1,23 @@
 package kr.hhplus.be.server.infrastructure.core.seat;
 
+import kr.hhplus.be.server.domain.concert.Concert;
 import kr.hhplus.be.server.domain.seat.Seat;
 import kr.hhplus.be.server.domain.seat.type.SeatStatus;
+import kr.hhplus.be.server.infrastructure.core.concert.ConcertJpaRepository;
+import kr.hhplus.be.server.infrastructure.redis.SeatRedisRepository;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static kr.hhplus.be.server.infrastructure.redis.SeatRedisRepository.UNAVAILABLE_SEAT_SET_PREFIX;
+import static kr.hhplus.be.server.infrastructure.redis.TokenRedisRepository.ACTIVE_TOKEN_SET_NAME;
+import static kr.hhplus.be.server.infrastructure.redis.TokenRedisRepository.WAIT_TOKEN_SET_NAME;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -17,6 +27,10 @@ class SeatModifierRepositoryImplTest {
 
     @Autowired
     private SeatJpaRepository seatJpaRepository;
+    @Autowired
+    private SeatRedisRepository seatRedisRepository;
+    @Autowired
+    private ConcertJpaRepository concertJpaRepository;
 
     @Transactional
     @Test
@@ -36,5 +50,32 @@ class SeatModifierRepositoryImplTest {
         Assertions.assertThat(
                 seatJpaRepository.findById(seat.getId()).get().getStatus()
         ).isEqualTo(SeatStatus.RESERVED);
+    }
+
+    @Transactional
+    @Test
+    void setReservedAndAvailable() {
+        // given
+        Seat seat = seatJpaRepository.findById(1L).get();
+
+        // when
+        seatModifierRepository.setReserved(seat);
+
+        // then
+        Assertions.assertThat(
+                seatRedisRepository
+                        .SetMembers(UNAVAILABLE_SEAT_SET_PREFIX + seat.getConcert().getDate())
+                        .contains(String.valueOf(seat.getNumber()))
+        ).isTrue();
+
+        // when
+        seatModifierRepository.setAvailable(seat);
+
+        // then
+        Assertions.assertThat(
+                seatRedisRepository
+                        .SetMembers(UNAVAILABLE_SEAT_SET_PREFIX + seat.getConcert().getDate())
+                        .contains(String.valueOf(seat.getNumber()))
+        ).isFalse();
     }
 }

--- a/src/test/java/kr/hhplus/be/server/infrastructure/core/seat/SeatReaderRepositoryImplTest.java
+++ b/src/test/java/kr/hhplus/be/server/infrastructure/core/seat/SeatReaderRepositoryImplTest.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.infrastructure.core.seat;
 
 import kr.hhplus.be.server.domain.seat.Seat;
+import kr.hhplus.be.server.infrastructure.redis.SeatRedisRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,7 +9,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
+
+import static kr.hhplus.be.server.infrastructure.redis.SeatRedisRepository.UNAVAILABLE_SEAT_SET_PREFIX;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -18,6 +22,8 @@ class SeatReaderRepositoryImplTest {
 
     @Autowired
     private SeatJpaRepository seatJpaRepository;
+    @Autowired
+    private SeatRedisRepository seatRedisRepository;
 
     @Transactional
     @Test
@@ -51,5 +57,22 @@ class SeatReaderRepositoryImplTest {
 
         // then
         Assertions.assertThat(expectedSeat).isNotNull();
+    }
+
+    @Test
+    void getUnavailableSeatsByDate() {
+        // given
+        seatRedisRepository.SetAdd(UNAVAILABLE_SEAT_SET_PREFIX + LocalDate.now(), String.valueOf(1));
+
+        // when
+        List<Long> seatNumberList = seatReaderRepository.getUnavailableSeatsByDate(LocalDate.now());
+
+        // then
+        Assertions.assertThat(seatNumberList.contains(1L)).isTrue();
+
+        // after
+        seatRedisRepository.SetRemove(
+                UNAVAILABLE_SEAT_SET_PREFIX + LocalDate.now(), String.valueOf(1)
+        );
     }
 }

--- a/src/test/java/kr/hhplus/be/server/infrastructure/core/waiting_queue/WaitingQueueModifierRepositoryImplTest.java
+++ b/src/test/java/kr/hhplus/be/server/infrastructure/core/waiting_queue/WaitingQueueModifierRepositoryImplTest.java
@@ -2,14 +2,21 @@ package kr.hhplus.be.server.infrastructure.core.waiting_queue;
 
 import kr.hhplus.be.server.domain.token.WaitingQueue;
 import kr.hhplus.be.server.domain.token.type.WaitingQueueStatus;
+import kr.hhplus.be.server.infrastructure.redis.TokenRedisRepository;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
+
+import static kr.hhplus.be.server.infrastructure.redis.TokenRedisRepository.ACTIVE_TOKEN_SET_NAME;
+import static kr.hhplus.be.server.infrastructure.redis.TokenRedisRepository.WAIT_TOKEN_SET_NAME;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -18,7 +25,20 @@ class WaitingQueueModifierRepositoryImplTest {
     private WaitingQueueModifierRepositoryImpl waitingQueueModifierRepository;
 
     @Autowired
+    private TokenRedisRepository tokenRedisRepository;
+    @Autowired
     private WaitingQueueJpaRepository waitingQueueJpaRepository;
+
+    @AfterEach
+    void clearRedisDB()
+    {
+        tokenRedisRepository.zSetRemoveRangeByScore(
+                ACTIVE_TOKEN_SET_NAME, Double.MIN_VALUE, Double.MAX_VALUE
+        );
+        tokenRedisRepository.zSetRemoveRangeByScore(
+                WAIT_TOKEN_SET_NAME, Double.MIN_VALUE, Double.MAX_VALUE
+        );
+    }
 
     @Transactional
     @Test
@@ -56,5 +76,52 @@ class WaitingQueueModifierRepositoryImplTest {
 
         // then
         Assertions.assertThat(waitingQueueJpaRepository.findById(token.getId())).isEmpty();
+    }
+
+    @Test
+    void deleteWaitTokens() {
+        // given
+        tokenRedisRepository.zSetAdd(WAIT_TOKEN_SET_NAME, "1234", 1);
+        tokenRedisRepository.zSetAdd(WAIT_TOKEN_SET_NAME, "2345", 2);
+        tokenRedisRepository.zSetAdd(WAIT_TOKEN_SET_NAME, "3456", 3);
+
+        // when
+        List<String> deletedTokens = waitingQueueModifierRepository.deleteWaitTokens(2);
+
+        // then
+        Assertions.assertThat(deletedTokens.size()).isEqualTo(2L);
+        Assertions.assertThat(
+                tokenRedisRepository.zSetScore(WAIT_TOKEN_SET_NAME, "3456")
+        ).isEqualTo(3);
+    }
+
+    @Test
+    void deleteAllExpiredTokens() {
+        // given
+        tokenRedisRepository.zSetAdd(ACTIVE_TOKEN_SET_NAME, "1234", 1);
+        tokenRedisRepository.zSetAdd(ACTIVE_TOKEN_SET_NAME, "2345", 2);
+        tokenRedisRepository.zSetAdd(ACTIVE_TOKEN_SET_NAME, "3456", 10);
+
+        // when
+        waitingQueueModifierRepository.deleteAllExpiredTokens(5);
+
+        // then
+        Assertions.assertThat(
+                tokenRedisRepository.zSetScore(ACTIVE_TOKEN_SET_NAME,"3456")
+        ).isEqualTo(10);
+    }
+
+    @Test
+    void changeExpiredTime() {
+        // given
+        tokenRedisRepository.zSetAdd(ACTIVE_TOKEN_SET_NAME, "1234", 1);
+
+        // when
+        waitingQueueModifierRepository.changeExpiredTime("1234", 10);
+
+        // then
+        Assertions.assertThat(
+                tokenRedisRepository.zSetScore(ACTIVE_TOKEN_SET_NAME, "1234")
+        ).isEqualTo(10);
     }
 }

--- a/src/test/java/kr/hhplus/be/server/infrastructure/core/waiting_queue/WaitingQueueWriterRepositoryImplTest.java
+++ b/src/test/java/kr/hhplus/be/server/infrastructure/core/waiting_queue/WaitingQueueWriterRepositoryImplTest.java
@@ -1,12 +1,17 @@
 package kr.hhplus.be.server.infrastructure.core.waiting_queue;
 
 import kr.hhplus.be.server.domain.token.WaitingQueue;
+import kr.hhplus.be.server.infrastructure.redis.TokenRedisRepository;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
+
+import static kr.hhplus.be.server.infrastructure.redis.TokenRedisRepository.ACTIVE_TOKEN_SET_NAME;
+import static kr.hhplus.be.server.infrastructure.redis.TokenRedisRepository.WAIT_TOKEN_SET_NAME;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -16,6 +21,19 @@ class WaitingQueueWriterRepositoryImplTest {
 
     @Autowired
     private WaitingQueueJpaRepository waitingQueueJpaRepository;
+    @Autowired
+    private TokenRedisRepository tokenRedisRepository;
+
+    @AfterEach
+    void clearRedisDB()
+    {
+        tokenRedisRepository.zSetRemoveRangeByScore(
+                ACTIVE_TOKEN_SET_NAME, Double.MIN_VALUE, Double.MAX_VALUE
+        );
+        tokenRedisRepository.zSetRemoveRangeByScore(
+                WAIT_TOKEN_SET_NAME, Double.MIN_VALUE, Double.MAX_VALUE
+        );
+    }
 
     @Transactional
     @Test
@@ -28,5 +46,27 @@ class WaitingQueueWriterRepositoryImplTest {
 
         // then
         Assertions.assertThat(waitingQueueJpaRepository.findById(token.getId())).isNotEmpty();
+    }
+
+    @Test
+    void writeWaitingToken() {
+        // when
+        waitingQueueWriterRepository.writeWaitingToken("1234", 1);
+
+        // then
+        Assertions.assertThat(
+                tokenRedisRepository.zSetCard(WAIT_TOKEN_SET_NAME)
+        ).isEqualTo(1L);
+    }
+
+    @Test
+    void writeActiveToken() {
+        // when
+        waitingQueueWriterRepository.writeActiveToken("1234", 1);
+
+        // then
+        Assertions.assertThat(
+                tokenRedisRepository.zSetCard(ACTIVE_TOKEN_SET_NAME)
+        ).isEqualTo(1L);
     }
 }


### PR DESCRIPTION
### **커밋 링크**
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->
- 레디스 대기열 토큰 기능 구현 : 992ab1b273c4fed662d97a6f6969183360ae11e3 <<-- STEP 14
※ 참고: 대기열은 레디스만 사용하도록 구현했지만 시간이 없어 엔티티를 지우는 등의 리팩토링은 수행하지 못했습니다. ㅠㅠ
- 이용가능 좌석 조회시 DB 부하 개선 및 테스트 코드 작성 (Redis 보조 DB 사용) : 1a1e6a843b79354652d90974d70cf1033d5ef263 <<-- STEP 13 (with WIKI)
- 콘서트 조회시 캐싱 구현 및 테스트 코드 작성 : 7433e510b15b3aca87c11904614a3fadbddf072f  <<-- STEP 13 (with WIKI)
- 캐시 스탬피드 현상 방지 (Redis 분산락) : 7bb68629e77b0fce63a164352734607819a7da41 <<-- STEP 13 (with WIKI)

---
### **리뷰 포인트(질문)**
- 리뷰 포인트 1
GenericJackson2JsonRedisSerializer를 지정한 cache 매니저로 **Cacheable**을 사용할 때, 반환되는 값인 List<클래스>을 deserialize하지 못해서 List<클래스>를 멤버변수로 갖도록 래핑한 Dto 클래스를 생성해야 한다거나 인자가 없는 생성자(NoArgsConstructor)를 생성해야한다거나 불편한 점이 많았습니다. ㅠㅠ
실무에서도 value를 GenericJackson2JsonRedisSerializer를 써서 직렬화하는지 궁금합니다. 또한 objectMapper가 어떻게 serialize하길래 저런 것들이 필요한지 원리가 궁금합니다.

- 리뷰 포인트 2
캐시 스탬피드 현상이 방지되는지 검증하는 테스트 코드 실행해보았는데, 분산락을 사용하지 않았을 경우 Fail이 나왔습니다. 멘토링때 **Cacheable**이 synchronized로 구현되었다고 말씀하신 것 같은데, synchronized로 구현이 되어있다면 기본적으로 한 인스턴스 내에서의 캐시 스탬피드 현상을 방지할 수 있어 Success가 나와야 하지 않을까요? 내부적으로 synchronized를 어떻게 써서 동작하는지 궁금합니다. 
<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
### **이번주 KPT 회고**

### Keep
레디스를 단순 캐시로 생각하는 것이 아니라 보조 DB 등 다양한 기능을 구현할 수 있는 매개체로 생각하는 등 레디스의 무궁무진한 가능성을 보았다. 레디스를 더 잘 써보고 싶다는 욕심이 생겼다.
<!-- 유지해야 할 좋은 점 -->

### Problem
GenericJackson2JsonRedisSerializer를 제대로 알지 못하고 사용한것 같다... 애를 많이 먹었다.
<!--개선이 필요한 점-->

### Try
레디스를 기똥차게 쓸 수 있는 방법을 생각해보고 조사해보기!
<!-- 새롭게 시도할 점 -->