### PR TITLE
Kafka를 활용한 성능 개선 및 아웃박스 패턴 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,9 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 	implementation("org.redisson:redisson-spring-boot-starter:3.18.0")
 
+	// kafka
+	implementation("org.springframework.kafka:spring-kafka")
+
 	// json
 	implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3")
 
@@ -54,6 +57,7 @@ dependencies {
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.boot:spring-boot-testcontainers")
+	testImplementation("org.testcontainers:kafka:1.20.1")
 	testImplementation("org.testcontainers:junit-jupiter")
 	testImplementation("org.testcontainers:mysql")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,46 @@
 version: '3'
 services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka1:
+    image: confluentinc/cp-kafka:latest
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka1:9092, PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+
+  kafka2:
+    image: confluentinc/cp-kafka:latest
+    ports:
+      - "9093:9092"
+    environment:
+      KAFKA_BROKER_ID: 2
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka2:9092, PLAINTEXT_HOST://localhost:9093
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+
+  kafka3:
+    image: confluentinc/cp-kafka:latest
+    ports:
+      - "9094:9092"
+    environment:
+      KAFKA_BROKER_ID: 3
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka3:9092, PLAINTEXT_HOST://localhost:9094
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+
   mysql:
     image: mysql:8.0
     ports:

--- a/src/main/java/kr/hhplus/be/server/api/reservation/application/ReservationApplication.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/application/ReservationApplication.java
@@ -23,6 +23,7 @@ import kr.hhplus.be.server.domain.token.type.WaitingQueueStatus;
 import kr.hhplus.be.server.domain.user.User;
 import kr.hhplus.be.server.domain.user.components.UserReader;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -90,7 +91,15 @@ public class ReservationApplication implements ReservationUsecase{
                 expiredTime.toEpochSecond(ZoneOffset.UTC) * 1_000_000_000 + expiredTime.getNano()
         );
 
-        reservationEventPublisher.success(new ReservationSuccessEvent());
+        reservationEventPublisher.success(
+                new ReservationSuccessEvent(
+                        user.getId(),
+                        String.format(
+                                "%s-%s-%s",
+                                reservation.getId(), concert.getName(), seat.getNumber()
+                        )
+                )
+        );
 
         return reservation;
     }

--- a/src/main/java/kr/hhplus/be/server/api/reservation/application/ReservationConsumer.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/application/ReservationConsumer.java
@@ -1,0 +1,39 @@
+package kr.hhplus.be.server.api.reservation.application;
+
+import kr.hhplus.be.server.domain.outbox.Outbox;
+import kr.hhplus.be.server.domain.outbox.components.OutboxCommander;
+import kr.hhplus.be.server.domain.outbox.components.OutboxReader;
+import kr.hhplus.be.server.domain.outbox.type.OutboxStatus;
+import kr.hhplus.be.server.infrastructure.dataplatform.DataPlatformMockApiClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ReservationConsumer {
+    private final DataPlatformMockApiClient dataPlatformMockApiClient;
+    private final OutboxCommander outboxCommander;
+    private final OutboxReader outboxReader;
+
+    @KafkaListener(topics = {"reserveSeat"}, groupId = "reservation")
+    public void listen(String reservationInfo)
+    {
+        try {
+            dataPlatformMockApiClient.sendReservation(reservationInfo);
+            String[] splits = reservationInfo.split("-");
+            // outbox 상태 변경 (published)
+            Outbox outbox = outboxReader.readByReservationId(Long.valueOf(splits[0]));
+            outbox.setStatus(OutboxStatus.PUBLISHED);
+            outboxCommander.writeOutbox(outbox);
+        } catch (RuntimeException re)
+        {
+            log.error("{}", re.getMessage());
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/application/ReservationEventListener.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/application/ReservationEventListener.java
@@ -1,22 +1,65 @@
 package kr.hhplus.be.server.api.reservation.application;
 
 import kr.hhplus.be.server.api.reservation.dto.ReservationSuccessEvent;
+import kr.hhplus.be.server.domain.outbox.Outbox;
+import kr.hhplus.be.server.domain.outbox.components.OutboxCommander;
+import kr.hhplus.be.server.domain.outbox.components.OutboxReader;
+import kr.hhplus.be.server.domain.outbox.type.OutboxStatus;
 import kr.hhplus.be.server.infrastructure.dataplatform.DataPlatformMockApiClient;
 import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.lang.reflect.Array;
+import java.time.LocalDateTime;
+
 @Component
 @RequiredArgsConstructor
 public class ReservationEventListener {
-    private final DataPlatformMockApiClient dataPlatformMockApiClient;
+    private final NewTopic reservationTopic;
+    private final KafkaTemplate<Long, String> kafkaTemplate;
+    private final OutboxReader outboxReader;
+    private final OutboxCommander outboxCommander;
 
-    @Async
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void saveOutbox(ReservationSuccessEvent event)
+    {
+        String[] splits = event.reservationInfo().split("-");
+        // outbox 상태 저장 (init)
+        outboxCommander.writeOutbox(
+                Outbox.builder()
+                        .reservationId(Long.valueOf(splits[0]))
+                        .key(event.userId())
+                        .payload(event.reservationInfo())
+                        .status(OutboxStatus.INIT)
+                        .createdAt(LocalDateTime.now())
+                        .build()
+        );
+    }
+
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void reservationSuccessHandler(ReservationSuccessEvent event)
     {
-        dataPlatformMockApiClient.sendReservation();
+        kafkaTemplate.send(
+                reservationTopic.name(), event.userId(), event.reservationInfo()
+        );
+    }
+
+    // 책임 분리 필요
+    @Scheduled(cron = "")
+    public void republish()
+    {
+        outboxReader.readAllByStatus(OutboxStatus.INIT).forEach(o -> {
+                    if (o.getCreatedAt().isBefore(LocalDateTime.now().minusMinutes(5)))
+                    {
+                        kafkaTemplate.send(reservationTopic.name(), o.getKey(), o.getPayload());
+                    }
+                }
+        );
     }
 }

--- a/src/main/java/kr/hhplus/be/server/api/reservation/dto/ReservationSuccessEvent.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/dto/ReservationSuccessEvent.java
@@ -1,4 +1,8 @@
 package kr.hhplus.be.server.api.reservation.dto;
 
-public class ReservationSuccessEvent {
+import kr.hhplus.be.server.domain.reservation.Reservation;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+public record ReservationSuccessEvent(Long userId, String reservationInfo) {
 }

--- a/src/main/java/kr/hhplus/be/server/common/config/kafka/ConsumerConfig.java
+++ b/src/main/java/kr/hhplus/be/server/common/config/kafka/ConsumerConfig.java
@@ -1,0 +1,55 @@
+package kr.hhplus.be.server.common.config.kafka;
+
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.kafka.clients.consumer.ConsumerConfig.*;
+
+@Configuration
+@EnableKafka
+public class ConsumerConfig {
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<Long, String>> kafkaListenerContainerFactory()
+    {
+        ConcurrentKafkaListenerContainerFactory<Long, String> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        factory.setConcurrency(3); // 의미?
+        factory.getContainerProperties().setPollTimeout(3000); // 의미?
+
+        return factory;
+    }
+
+    @Bean
+    public ConsumerFactory<Long, String> consumerFactory()
+    {
+        return new DefaultKafkaConsumerFactory<>(consumerConfigs());
+    }
+
+    @Bean
+    public Map<String, Object> consumerConfigs()
+    {
+        Map<String, Object> props = new HashMap<>();
+        props.put(BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(KEY_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class);
+        props.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        return props;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/common/config/kafka/ProducerConfig.java
+++ b/src/main/java/kr/hhplus/be/server/common/config/kafka/ProducerConfig.java
@@ -1,0 +1,45 @@
+package kr.hhplus.be.server.common.config.kafka;
+
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.kafka.clients.producer.ProducerConfig.*;
+
+@Configuration
+public class ProducerConfig {
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<Long, String> producerFactory()
+    {
+        return new DefaultKafkaProducerFactory<>(producerConfigs());
+    }
+
+    @Bean
+    public Map<String, Object> producerConfigs()
+    {
+        Map<String, Object> props = new HashMap<>();
+        props.put(BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(KEY_SERIALIZER_CLASS_CONFIG, LongSerializer.class);
+        props.put(VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+        return props;
+    }
+
+    @Bean
+    public KafkaTemplate<Long, String> kafkaTemplate()
+    {
+        return new KafkaTemplate<Long, String>(producerFactory());
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/common/config/kafka/TopicConfig.java
+++ b/src/main/java/kr/hhplus/be/server/common/config/kafka/TopicConfig.java
@@ -1,0 +1,42 @@
+package kr.hhplus.be.server.common.config.kafka;
+
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.KafkaAdmin;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class TopicConfig {
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Value("${spring.kafka.replicas}")
+    private Integer replicas;
+
+    @Value("${spring.kafka.partitions}")
+    private Integer partitions;
+
+    @Bean
+    public KafkaAdmin admin()
+    {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        return new KafkaAdmin(configs);
+    }
+
+    @Bean
+    public NewTopic reservationTopic()
+    {
+        return TopicBuilder.name("reserveSeat")
+                .partitions(partitions)
+                .replicas(replicas)
+//                .compact()
+                .build();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/outbox/Outbox.java
+++ b/src/main/java/kr/hhplus/be/server/domain/outbox/Outbox.java
@@ -1,0 +1,32 @@
+package kr.hhplus.be.server.domain.outbox;
+
+import jakarta.persistence.*;
+import kr.hhplus.be.server.domain.outbox.type.OutboxStatus;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@Entity
+@Table(name = "outbox")
+@NoArgsConstructor
+@AllArgsConstructor
+public class Outbox {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "outbox_id")
+    private Long id;
+
+    private Long reservationId;
+
+    @Column(name = "key_name")
+    private Long key;
+    private String payload;
+
+    private LocalDateTime createdAt;
+
+    @Setter
+    @Enumerated(EnumType.STRING)
+    private OutboxStatus status;
+}

--- a/src/main/java/kr/hhplus/be/server/domain/outbox/components/OutboxCommander.java
+++ b/src/main/java/kr/hhplus/be/server/domain/outbox/components/OutboxCommander.java
@@ -1,0 +1,17 @@
+package kr.hhplus.be.server.domain.outbox.components;
+
+import kr.hhplus.be.server.domain.outbox.Outbox;
+import kr.hhplus.be.server.domain.outbox.repositories.OutboxCommandRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OutboxCommander {
+    private final OutboxCommandRepository outboxCommandRepository;
+
+    public void writeOutbox(Outbox outbox)
+    {
+        outboxCommandRepository.writeOutbox(outbox);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/outbox/components/OutboxReader.java
+++ b/src/main/java/kr/hhplus/be/server/domain/outbox/components/OutboxReader.java
@@ -1,0 +1,26 @@
+package kr.hhplus.be.server.domain.outbox.components;
+
+import kr.hhplus.be.server.domain.outbox.Outbox;
+import kr.hhplus.be.server.domain.outbox.repositories.OutboxReaderRepository;
+import kr.hhplus.be.server.domain.outbox.type.OutboxStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class OutboxReader {
+    private final OutboxReaderRepository outboxReaderRepository;
+
+    public List<Outbox> readAllByStatus(OutboxStatus status)
+    {
+        return outboxReaderRepository.readAllByStatus(status);
+    }
+
+    public Outbox readByReservationId(Long reservationId)
+    {
+        return outboxReaderRepository.readByReservationId(reservationId)
+                .orElseThrow(() -> new RuntimeException(""));
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/outbox/repositories/OutboxCommandRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/outbox/repositories/OutboxCommandRepository.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.domain.outbox.repositories;
+
+import kr.hhplus.be.server.domain.outbox.Outbox;
+
+public interface OutboxCommandRepository {
+    public void writeOutbox(Outbox outbox);
+}

--- a/src/main/java/kr/hhplus/be/server/domain/outbox/repositories/OutboxReaderRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/outbox/repositories/OutboxReaderRepository.java
@@ -1,0 +1,12 @@
+package kr.hhplus.be.server.domain.outbox.repositories;
+
+import kr.hhplus.be.server.domain.outbox.Outbox;
+import kr.hhplus.be.server.domain.outbox.type.OutboxStatus;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface OutboxReaderRepository {
+    public List<Outbox> readAllByStatus(OutboxStatus status);
+    public Optional<Outbox> readByReservationId(Long reservationId);
+}

--- a/src/main/java/kr/hhplus/be/server/domain/outbox/type/OutboxStatus.java
+++ b/src/main/java/kr/hhplus/be/server/domain/outbox/type/OutboxStatus.java
@@ -1,0 +1,6 @@
+package kr.hhplus.be.server.domain.outbox.type;
+
+public enum OutboxStatus {
+    INIT,
+    PUBLISHED
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/core/outbox/OutboxCommandRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/core/outbox/OutboxCommandRepositoryImpl.java
@@ -1,0 +1,17 @@
+package kr.hhplus.be.server.infrastructure.core.outbox;
+
+import kr.hhplus.be.server.domain.outbox.Outbox;
+import kr.hhplus.be.server.domain.outbox.repositories.OutboxCommandRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class OutboxCommandRepositoryImpl implements OutboxCommandRepository {
+    private final OutboxJpaRepository outboxJpaRepository;
+
+    @Override
+    public void writeOutbox(Outbox outbox) {
+        outboxJpaRepository.save(outbox);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/core/outbox/OutboxJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/core/outbox/OutboxJpaRepository.java
@@ -1,0 +1,15 @@
+package kr.hhplus.be.server.infrastructure.core.outbox;
+
+import kr.hhplus.be.server.domain.outbox.Outbox;
+import kr.hhplus.be.server.domain.outbox.type.OutboxStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface OutboxJpaRepository extends JpaRepository<Outbox, Long> {
+    public List<Outbox> findAllByStatus(OutboxStatus status);
+    public Optional<Outbox> findByReservationId(Long reservationId);
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/core/outbox/OutboxReaderRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/core/outbox/OutboxReaderRepositoryImpl.java
@@ -1,0 +1,26 @@
+package kr.hhplus.be.server.infrastructure.core.outbox;
+
+import kr.hhplus.be.server.domain.outbox.Outbox;
+import kr.hhplus.be.server.domain.outbox.repositories.OutboxReaderRepository;
+import kr.hhplus.be.server.domain.outbox.type.OutboxStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class OutboxReaderRepositoryImpl implements OutboxReaderRepository {
+    private final OutboxJpaRepository outboxJpaRepository;
+
+    @Override
+    public List<Outbox> readAllByStatus(OutboxStatus status) {
+        return outboxJpaRepository.findAllByStatus(status);
+    }
+
+    @Override
+    public Optional<Outbox> readByReservationId(Long reservationId) {
+        return outboxJpaRepository.findByReservationId(reservationId);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/dataplatform/DataPlatformMockApiClient.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/dataplatform/DataPlatformMockApiClient.java
@@ -4,10 +4,10 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class DataPlatformMockApiClient {
-    public void sendReservation()
+    public void sendReservation(String reservationInfo)
     {
-        // 무조건 실패
-        System.out.println("예약 데이터 전송 실패");
-        throw new RuntimeException();
+        // 무조건 성공
+        System.out.println("예약 데이터 전송 성공");
+//        throw new RuntimeException();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,11 @@ spring:
       host: localhost
       port: 6379
 
+  kafka:
+    bootstrap-servers: localhost:9092
+    replicas: 2
+    partitions: 3
+
 ---
 spring.config.activate.on-profile: test
 spring:

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -4,6 +4,7 @@ TRUNCATE TABLE waiting_queue;
 TRUNCATE TABLE reservation;
 TRUNCATE TABLE payment;
 TRUNCATE TABLE user;
+TRUNCATE TABLE outbox;
 
 
 INSERT INTO user(balance) VALUES(0);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -33,6 +33,7 @@ CREATE TABLE IF NOT EXISTS reservation (
   `version` int not null default 0
 );
 
+
 CREATE TABLE IF NOT EXISTS payment (
   `payment_id` int AUTO_INCREMENT PRIMARY KEY,
   `reservation_id` int,
@@ -46,4 +47,13 @@ CREATE TABLE IF NOT EXISTS user (
   `balance` int,
   `uuid` varchar(255),
   `version` int not null default 0
+);
+
+CREATE TABLE IF NOT EXISTS outbox (
+    `outbox_id` int AUTO_INCREMENT PRIMARY KEY,
+    `reservation_id` int,
+    `key_name` int,
+    `payload` varchar(255),
+    `status` varchar(255),
+    `created_at` datetime
 );

--- a/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
+++ b/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -13,6 +14,7 @@ class TestcontainersConfiguration {
 
 	public static final MySQLContainer<?> MYSQL_CONTAINER;
 	public static final GenericContainer<?> REDIS_CONTAINER;
+	public static final KafkaContainer KAFKA_CONTAINER;
 
 	static {
 		MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
@@ -31,6 +33,13 @@ class TestcontainersConfiguration {
 
 		System.setProperty("spring.data.redis.host", REDIS_CONTAINER.getHost());
 		System.setProperty("spring.data.redis.port", REDIS_CONTAINER.getMappedPort(6379).toString());
+
+		KAFKA_CONTAINER = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.1"));
+		KAFKA_CONTAINER.start();
+
+		System.setProperty("spring.kafka.bootstrap-servers", KAFKA_CONTAINER.getBootstrapServers());
+		System.setProperty("spring.kafka.replicas", "1");
+		System.setProperty("spring.kafka.partitions", "3");
 	}
 
 	@PreDestroy
@@ -41,6 +50,10 @@ class TestcontainersConfiguration {
 		if (REDIS_CONTAINER.isRunning())
 		{
 			REDIS_CONTAINER.stop();
+		}
+		if (KAFKA_CONTAINER.isRunning())
+		{
+			KAFKA_CONTAINER.stop();
 		}
 	}
 }

--- a/src/test/java/kr/hhplus/be/server/api/reservation/application/ReservationApplicationIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/reservation/application/ReservationApplicationIntegrationTest.java
@@ -2,14 +2,17 @@ package kr.hhplus.be.server.api.reservation.application;
 
 import kr.hhplus.be.server.api.token.application.TokenApplication;
 import kr.hhplus.be.server.common.Interceptor.UserContext;
+import kr.hhplus.be.server.domain.outbox.components.OutboxReader;
+import kr.hhplus.be.server.domain.outbox.type.OutboxStatus;
 import kr.hhplus.be.server.domain.reservation.Reservation;
 import kr.hhplus.be.server.domain.reservation.type.ReservationStatus;
 import kr.hhplus.be.server.domain.seat.type.SeatStatus;
-import kr.hhplus.be.server.domain.token.WaitingQueue;
 import kr.hhplus.be.server.domain.token.components.WaitingQueueReader;
 import kr.hhplus.be.server.domain.token.components.WaitingQueueWriter;
-import kr.hhplus.be.server.domain.token.type.WaitingQueueStatus;
 import kr.hhplus.be.server.domain.user.User;
+import kr.hhplus.be.server.infrastructure.core.outbox.OutboxJpaRepository;
+import kr.hhplus.be.server.infrastructure.core.reservation.ReservationJpaRepository;
+import kr.hhplus.be.server.infrastructure.core.seat.SeatJpaRepository;
 import kr.hhplus.be.server.infrastructure.core.user.UserJpaRepository;
 import kr.hhplus.be.server.infrastructure.core.waiting_queue.WaitingQueueJpaRepository;
 import org.assertj.core.api.Assertions;
@@ -19,15 +22,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 import org.testcontainers.shaded.org.apache.commons.lang3.time.StopWatch;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 
 @ActiveProfiles("test")
@@ -39,20 +41,27 @@ class ReservationApplicationIntegrationTest {
     private UserJpaRepository userJpaRepository;
     @Autowired
     private WaitingQueueJpaRepository waitingQueueJpaRepository;
+    @Autowired
+    private ReservationJpaRepository reservationJpaRepository;
+    @Autowired
+    private SeatJpaRepository seatJpaRepository;
+    @Autowired
+    private OutboxJpaRepository outboxJpaRepository;
 
     @Autowired
     private WaitingQueueReader waitingQueueReader;
     @Autowired
     private WaitingQueueWriter waitingQueueWriter;
+    @Autowired
+    private OutboxReader outboxReader;
 
     @Autowired
     private ReservationApplication reservationApplication;
     @Autowired
     private TokenApplication tokenApplication;
 
-    @Transactional
     @Test
-    void reserveSeat() {
+    void reserveSeat() throws InterruptedException {
         // given
         User user = userJpaRepository.save(
                 User.builder()
@@ -73,9 +82,22 @@ class ReservationApplicationIntegrationTest {
                         25L
                 );
 
+        // kafka 발행을 기다림
+        Thread.sleep(3000);
+
         // then
+        Assertions.assertThat(
+                outboxReader.readByReservationId(reservation.getId()).getStatus()
+        ).isEqualTo(OutboxStatus.PUBLISHED);
         Assertions.assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.PAYMENT_REQUIRED);
         Assertions.assertThat(reservation.getSeat().getStatus()).isEqualTo(SeatStatus.RESERVED);
+
+        // data 원상 복구
+        reservation.getSeat().setStatus(SeatStatus.AVAILABLE);
+        seatJpaRepository.save(reservation.getSeat());
+        userJpaRepository.delete(user);
+        outboxJpaRepository.delete(outboxReader.readByReservationId(reservation.getId()));
+        reservationJpaRepository.delete(reservation);
     }
 
     @Test

--- a/src/test/java/kr/hhplus/be/server/api/reservation/application/ReservationApplicationUnitTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/reservation/application/ReservationApplicationUnitTest.java
@@ -49,6 +49,8 @@ class ReservationApplicationUnitTest {
     private SeatModifier seatModifier;
     @Mock
     private WaitingQueueModifier waitingQueueModifier;
+    @Mock
+    private ReservationEventPublisher reservationEventPublisher;
 
     @InjectMocks
     private ReservationApplication reservationApplication;

--- a/src/test/java/kr/hhplus/be/server/api/seat/application/SeatApplicationUnitTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/seat/application/SeatApplicationUnitTest.java
@@ -6,6 +6,7 @@ import kr.hhplus.be.server.domain.reservation.components.ReservationModifier;
 import kr.hhplus.be.server.domain.reservation.components.ReservationReader;
 import kr.hhplus.be.server.domain.reservation.type.ReservationStatus;
 import kr.hhplus.be.server.domain.seat.Seat;
+import kr.hhplus.be.server.domain.seat.components.SeatModifier;
 import kr.hhplus.be.server.domain.token.WaitingQueue;
 import kr.hhplus.be.server.domain.token.components.WaitingQueueReader;
 import kr.hhplus.be.server.domain.token.type.WaitingQueueStatus;
@@ -34,6 +35,8 @@ class SeatApplicationUnitTest {
     private ReservationModifier reservationModifier;
     @Mock
     private UserReader userReader;
+    @Mock
+    private SeatModifier seatModifier;
 
     @InjectMocks
     private SeatApplication seatApplication;

--- a/src/test/java/kr/hhplus/be/server/infrastructure/core/outbox/OutboxReaderRepositoryImplTest.java
+++ b/src/test/java/kr/hhplus/be/server/infrastructure/core/outbox/OutboxReaderRepositoryImplTest.java
@@ -1,0 +1,72 @@
+package kr.hhplus.be.server.infrastructure.core.outbox;
+
+import kr.hhplus.be.server.domain.outbox.Outbox;
+import kr.hhplus.be.server.domain.outbox.type.OutboxStatus;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class OutboxReaderRepositoryImplTest {
+    @Autowired
+    private OutboxReaderRepositoryImpl outboxReaderRepository;
+    @Autowired
+    private OutboxJpaRepository outboxJpaRepository;
+
+    @BeforeEach
+    void addData()
+    {
+        outboxJpaRepository.save(
+                Outbox.builder().reservationId(100L).status(OutboxStatus.INIT).build()
+        );
+        outboxJpaRepository.save(
+                Outbox.builder().reservationId(101L).status(OutboxStatus.INIT).build()
+        );
+        outboxJpaRepository.save(
+            Outbox.builder().reservationId(102L).status(OutboxStatus.INIT).build()
+        );
+        outboxJpaRepository.save(
+            Outbox.builder().reservationId(103L).status(OutboxStatus.PUBLISHED).build()
+        );
+        outboxJpaRepository.save(
+            Outbox.builder().reservationId(104L).status(OutboxStatus.PUBLISHED).build()
+        );
+    }
+
+    @AfterEach
+    void deleteData()
+    {
+        outboxJpaRepository.deleteAll();
+    }
+
+    @Test
+    void readAllByStatus() {
+//        // when
+        List<Outbox> outboxList =
+                outboxReaderRepository.readAllByStatus(OutboxStatus.INIT);
+
+        // then
+        Assertions.assertThat(outboxList.size()).isEqualTo(3L);
+    }
+
+    @Test
+    void readByReservationId() {
+        // when
+        Outbox outbox =
+                outboxReaderRepository.readByReservationId(104L).get();
+
+        // then
+        Assertions.assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.PUBLISHED);
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/infrastructure/kafka/KafkaIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/infrastructure/kafka/KafkaIntegrationTest.java
@@ -1,0 +1,27 @@
+package kr.hhplus.be.server.infrastructure.kafka;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.concurrent.TimeUnit;
+
+@ActiveProfiles("test")
+@SpringBootTest
+public class KafkaIntegrationTest {
+    @Autowired
+    KafkaTemplate<Long, String> kafkaTemplate;
+
+    @Test
+    public void test() throws InterruptedException {
+        kafkaTemplate.send("test_topic", 1L, "test_data");
+
+        KafkaTestConsumer.latch.await(10000, TimeUnit.MILLISECONDS);
+
+        Assertions.assertThat(KafkaTestConsumer.latch.getCount()).isEqualTo(0L);
+        Assertions.assertThat(KafkaTestConsumer.payload).isEqualTo("test_data");
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/infrastructure/kafka/KafkaTestConsumer.java
+++ b/src/test/java/kr/hhplus/be/server/infrastructure/kafka/KafkaTestConsumer.java
@@ -1,0 +1,20 @@
+package kr.hhplus.be.server.infrastructure.kafka;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.CountDownLatch;
+
+@Component
+class KafkaTestConsumer
+{
+    public final static CountDownLatch latch = new CountDownLatch(1);
+    public static String payload;
+
+    @KafkaListener(topics = {"test_topic"}, groupId = "test")
+    public void listen(String message)
+    {
+        payload = message;
+        latch.countDown();
+    }
+}


### PR DESCRIPTION
### **커밋 링크**
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->
- kafka 테스트 및 실행 환경 구성, kafka 연동 통합 테스트 작성: 66e8e98a801a56f215d28f2d78a7e3d2e3b8eba6 <- STEP  17
- 예약시 kafka + outbox 패턴 적용 및 통합 테스트 코드 작성: 1551ec2f3bedb89d549e7733b93ea02d8bdcb2f7 <-  STEP 18
- 단위 테스트 코드 수정: 294bc67c0612d1303afc49b0051b75d3e5128853
---
### **리뷰 포인트(질문)**
- 리뷰 포인트 1
kafka producer를 설정할 때, 공식문서에 나와있는 대로 concurrency값과 pollTimeout값을 설정했습니다. 하지만 해당 설정값이 무엇을 의미하는지 제대로 이해하지 못했습니다 ㅠㅠ. 각각의 설정이 무엇을 의미하는지 설명을 듣고 싶습니다.
- 리뷰 포인트 2
reservationConsumer를 어떤 레이어에 두어야 할지 고민이 많았습니다. infrastructure에 두면 consumer가 outbox repository에 의존하므로 infrastructure 레이어에서 infrastructure 레이어로 의존하는 관계가 만들어질까봐 application 레이어에 두었습니다. 잘한 선택일까요?
- 리뷰 포인트 3
모든 테스트를 한번에 수행할 때, 테스트 순서에 kafka 연동 테스트가 영향을 받는 (먼저 수행되면 성공이지만 나중에 수행되면 실패)  아이러니한 상황이 발생하였습니다. 다른 학습메이트분과 고민하여 Autowired + kafkaTestConsumer 변수에 실제 어플리케이션 빈이 아닌 다른 객체가 주입되는 것을 확인했습니다(객체의 hashcode() 가 다름). 이에 Autowired를 제거하고 static 키워드를 사용하여 클래스로 접근할 수 있도록 하여 해결했는데, 왜 테스트를 한번에 수행하니 Autowired에 주입되는 빈이 엉켜버리는 건지 원인을 모르겠습니다. ㅠ
<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
### **이번주 KPT 회고**

### Keep
끝까지 파고들기 (포기할까 생각했지만 통합테스트까지 완료한것 같아 뿌듯했다!)
<!-- 유지해야 할 좋은 점 -->

### Problem
아직도 kafka를 깊게 이해하지 못한것 같아 여운이 남는다.
<!--개선이 필요한 점-->

### Try
부족한 부분을 체크하고 시간이 날 때 더 깊이 이해해보는 노력을 해보자!
<!-- 새롭게 시도할 점 -->